### PR TITLE
Fix encryption of batches of records

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
@@ -224,6 +224,7 @@ public class InBandKeyManager<K, E> implements KeyManager<K> {
         }
         else {
             ByteBuffer plaintext = kafkaRecord.value();
+            keyContext.encodedSize(kafkaRecord.valueSize());
             keyContext.encode(plaintext, valueCiphertext);
             valueCiphertext.flip();
             transformedValue = valueCiphertext;


### PR DESCRIPTION
Currently shouldEncryptRecordValueForMultipleRecords is failing with:

```
Caused by: java.lang.IllegalStateException: Call to encrypt() without last call being to outputSize()
	at io.kroxylicious.filter.encryption.inband.AesGcmEncryptor.encrypt(AesGcmEncryptor.java:93)
	at io.kroxylicious.filter.encryption.inband.KeyContext.encode(KeyContext.java:73)
	at io.kroxylicious.filter.encryption.inband.InBandKeyManager.encryptRecordValue(InBandKeyManager.java:227)
	at io.kroxylicious.filter.encryption.inband.InBandKeyManager.lambda$encryptRecords$6(InBandKeyManager.java:189)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at io.kroxylicious.filter.encryption.inband.InBandKeyManager.encryptRecords(InBandKeyManager.java:185)
	at io.kroxylicious.filter.encryption.inband.InBandKeyManager.lambda$encrypt$5(InBandKeyManager.java:167)
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptNow(CompletableFuture.java:757)
	at java.base/java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:735)
	at java.base/java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:2214)
	at java.base/java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:144)
	at io.kroxylicious.filter.encryption.inband.InBandKeyManager.encrypt(InBandKeyManager.java:159)
	at io.kroxylicious.filter.encryption.inband.InBandKeyManagerTest.shouldEncryptRecordValueForMultipleRecords(InBandKeyManagerTest.java:133)
	... 3 more
	```