### PR TITLE
Obtain a new KeyContext if the old one expires or runs out of encryptions

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -47,7 +47,7 @@ public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryptio
         KmsService<Object, K, E> kmsPlugin = context.pluginInstance(KmsService.class, configuration.kms());
         Kms<K, E> kms = kmsPlugin.buildKms(configuration.kmsConfig());
 
-        var keyManager = new InBandKeyManager<>(kms, BufferPool.allocating());
+        var keyManager = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000);
 
         KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, configuration.selector());
         TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(kms, configuration.selectorConfig());

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -51,6 +51,10 @@ final class KeyContext implements Destroyable {
         return remainingEncryptions.getAndAdd(-numEncryptions) >= numEncryptions;
     }
 
+    public int remainingEncryptions() {
+        return remainingEncryptions.get();
+    }
+
     /**
      * Returns the size of the encoding of a plaintext of the given size
      * @param plaintextSize The plaintext.


### PR DESCRIPTION
When obtaining a future through getKeyContext, if the cached future is done we check if it can handle the next batch of encryptions, if not we request a new keyContext and cache the new future.
    
Why:
We need to change to a new DEK after some amount of encryption work because by the NIST guidelines we should only use the key material to encrypt some limited amount of data and it should also have some limited lifetime