### PR TITLE
Use DEK manager on encryption path

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/DecryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/DecryptionManager.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.IntFunction;
+
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A manager of (data) encryption keys supporting decryption operations,
+ * encapsulating access to the data encryption keys.
+ */
+public interface DecryptionManager {
+    /**
+     * Asynchronously decrypt the given {@code records}, returning a MemoryRecords object which will contain all records transformed to their decrypted form (if required)
+     * @param topicName The topic name
+     * @param partition The partition index
+     * @param records The records
+     * @param bufferAllocator Allocator of ByteBufferOutputStream
+     * @return A completion stage that completes with the output MemoryRecords when all the records have been processed and transformed.
+     */
+    @NonNull
+    CompletionStage<MemoryRecords> decrypt(
+                                           @NonNull String topicName,
+                                           int partition,
+                                           @NonNull MemoryRecords records,
+                                           @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator);
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionManager.java
@@ -15,12 +15,11 @@ import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A manager of (data) encryption keys supporting encryption and decryption operations,
+ * A manager of (data) encryption keys supporting encryption operations,
  * encapsulating access to the data encryption keys.
  * @param <K> The type of KEK id.
  */
-public interface KeyManager<K> {
-
+public interface EncryptionManager<K> {
     /**
      * Asynchronously encrypt the given {@code records} using the current DEK for the given KEK returning a MemoryRecords object which will contain all records
      * transformed according to the {@code encryptionScheme}.
@@ -30,23 +29,10 @@ public interface KeyManager<K> {
      * @return A completion stage that completes with the output MemoryRecords when all the records have been processed and transformed.
      */
     @NonNull
-    CompletionStage<MemoryRecords> encrypt(@NonNull String topicName,
+    CompletionStage<MemoryRecords> encrypt(
+                                           @NonNull String topicName,
                                            int partition,
                                            @NonNull EncryptionScheme<K> encryptionScheme,
-                                           @NonNull MemoryRecords records,
-                                           @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator);
-
-    /**
-     * Asynchronously decrypt the given {@code records}, returning a MemoryRecords object which will contain all records transformed to their decrypted form (if required)
-     * @param topicName The topic name
-     * @param partition The partition index
-     * @param records The records
-     * @param bufferAllocator Allocator of ByteBufferOutputStream
-     * @return A completion stage that completes with the output MemoryRecords when all the records have been processed and transformed.
-     */
-    @NonNull
-    CompletionStage<MemoryRecords> decrypt(@NonNull String topicName,
-                                           int partition,
                                            @NonNull MemoryRecords records,
                                            @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator);
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -73,7 +73,7 @@ public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryptio
 
         KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, configuration.selector());
         TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(kms, configuration.selectorConfig());
-        return new EnvelopeEncryptionFilter<>(keyManager, kekSelector);
+        return new EnvelopeEncryptionFilter<>(keyManager, keyManager, kekSelector);
     }
 
     @NonNull

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.micrometer.core.instrument.Metrics;
 
+import io.kroxylicious.filter.encryption.dek.DekManager;
 import io.kroxylicious.filter.encryption.inband.BufferPool;
 import io.kroxylicious.filter.encryption.inband.InBandDecryptionManager;
 import io.kroxylicious.filter.encryption.inband.InBandEncryptionManager;
@@ -70,7 +71,7 @@ public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryptio
     public EnvelopeEncryptionFilter<K> createFilter(FilterFactoryContext context, Config configuration) {
         Kms<K, E> kms = buildKms(context, configuration);
 
-        var encryptionManager = new InBandEncryptionManager<>(kms, BufferPool.allocating(), 500_000, 5_000_000_000L);
+        var encryptionManager = new InBandEncryptionManager<>(new DekManager<K, E>(ignored -> kms, null, 5_000_000), BufferPool.allocating());
         var decryptionManager = new InBandDecryptionManager<>(kms);
 
         KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, configuration.selector());

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilter.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilter.java
@@ -42,11 +42,14 @@ public class EnvelopeEncryptionFilter<K>
     private static final Logger log = getLogger(EnvelopeEncryptionFilter.class);
     private final TopicNameBasedKekSelector<K> kekSelector;
 
-    private final KeyManager<K> keyManager;
+    private final EncryptionManager<K> encryptionManager;
+    private final DecryptionManager decryptionManager;
 
-    EnvelopeEncryptionFilter(KeyManager<K> keyManager, TopicNameBasedKekSelector<K> kekSelector) {
+    EnvelopeEncryptionFilter(EncryptionManager<K> encryptionManager,
+                             DecryptionManager decryptionManager, TopicNameBasedKekSelector<K> kekSelector) {
         this.kekSelector = kekSelector;
-        this.keyManager = keyManager;
+        this.encryptionManager = encryptionManager;
+        this.decryptionManager = decryptionManager;
     }
 
     @SuppressWarnings("unchecked")
@@ -79,7 +82,7 @@ public class EnvelopeEncryptionFilter<K>
                                 return CompletableFuture.completedStage(ppd);
                             }
                             MemoryRecords records = (MemoryRecords) ppd.records();
-                            return keyManager.encrypt(
+                            return encryptionManager.encrypt(
                                     topicName,
                                     ppd.index(),
                                     new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
@@ -133,7 +136,7 @@ public class EnvelopeEncryptionFilter<K>
                                                               PartitionData fpr,
                                                               MemoryRecords memoryRecords,
                                                               FilterContext context) {
-        return keyManager.decrypt(
+        return decryptionManager.decrypt(
                 topicName,
                 fpr.partitionIndex(),
                 memoryRecords,

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherSpec.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherSpec.java
@@ -17,8 +17,6 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 
-import io.kroxylicious.filter.encryption.EncryptionException;
-
 /**
  * A CipherSpec couples a single persisted identifier with a Cipher (e.g. AES)
  * and means of generating, writing and reading parameters for that cipher.
@@ -143,7 +141,7 @@ public enum CipherSpec {
             return Cipher.getInstance(transformation);
         }
         catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-            throw new EncryptionException(e);
+            throw new DekException(e);
         }
     }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherSpec.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherSpec.java
@@ -27,7 +27,7 @@ public enum CipherSpec {
      * AES/GCM with 128-bit key, 96-bit IV and 128-bit tag.
      * @see <a href="https://www.ietf.org/rfc/rfc5116.txt">RFC-5116</a>
      */
-    AES_128_GCM_128(1,
+    AES_128_GCM_128(0,
             "AES/GCM/NoPadding",
             1L << 32 // 2^32
     ) {
@@ -67,7 +67,7 @@ public enum CipherSpec {
      * ChaCha20-Poly1305, which means 256-bit key, 96-bit nonce and 128-bit tag.
      * @see <a href="https://www.ietf.org/rfc/rfc7539.txt">RFC-7539</a>
      */
-    CHACHA20_POLY1305(2,
+    CHACHA20_POLY1305(1,
             "ChaCha20-Poly1305",
             Long.MAX_VALUE // 2^96 would be necessary given we use Wrapping96BitCounter
     // 2^63-1 is sufficient
@@ -108,9 +108,9 @@ public enum CipherSpec {
 
     static CipherSpec fromPersistentId(int persistentId) {
         switch (persistentId) {
-            case 1:
+            case 0:
                 return CipherSpec.AES_128_GCM_128;
-            case 2:
+            case 1:
                 return CipherSpec.CHACHA20_POLY1305;
             default:
                 throw new UnknownCipherSpecException("Cipher spec with persistent id " + persistentId + " is not known");
@@ -128,7 +128,7 @@ public enum CipherSpec {
         this.maxEncryptionsPerKey = maxEncryptionsPerKey;
     }
 
-    int persistentId() {
+    public int persistentId() {
         return persistentId;
     }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
@@ -299,6 +299,10 @@ public final class Dek<E> {
         return secretKey == null || secretKey.isDestroyed();
     }
 
+    public E edek() {
+        return edek;
+    }
+
     /**
      * A means of performing a limited number of encryption operations without access to key material.
      */
@@ -322,10 +326,10 @@ public final class Dek<E> {
         }
 
         /**
-         * @return The encrypted key
+         * @return The encrypted DEK
          */
-        public E edek() {
-            return edek;
+        public @NonNull E edek() {
+            return Dek.this.edek();
         }
 
         /**

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
@@ -28,9 +28,6 @@ import javax.security.auth.Destroyable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.filter.encryption.EncryptionException;
-import io.kroxylicious.filter.encryption.inband.ExhaustedDekException;
-
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -374,7 +371,7 @@ public final class Dek<E> {
                     return;
                 }
                 catch (GeneralSecurityException e) {
-                    throw new EncryptionException(e);
+                    throw new DekException(e);
                 }
             }
             throw new DekUsageException("The Encryptor has no more operations allowed");
@@ -424,7 +421,7 @@ public final class Dek<E> {
                 cipher.doFinal(ciphertext, plaintext);
             }
             catch (GeneralSecurityException e) {
-                throw new EncryptionException(e);
+                throw new DekException(e);
             }
         }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekException.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekException.java
@@ -6,12 +6,16 @@
 
 package io.kroxylicious.filter.encryption.dek;
 
-/**
- * Indicates that a {@link Dek} couldn't be used because it was destroyed.
- */
-public class DestroyedDekException extends DekException {
+public class DekException extends RuntimeException {
+    public DekException(String message) {
+        super((message));
+    }
 
-    public DestroyedDekException() {
+    public DekException() {
         super();
+    }
+
+    public DekException(Throwable cause) {
+        super(cause);
     }
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekUsageException.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekUsageException.java
@@ -10,7 +10,7 @@ package io.kroxylicious.filter.encryption.dek;
  * Indicates an attempt to use a DEK in a way that isn't allowed, for example
  * to encrypt when its limit on number of encryption operations has been reached.
  */
-public class DekUsageException extends RuntimeException {
+public class DekUsageException extends DekException {
     public DekUsageException(String message) {
         super(message);
     }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/EncryptAllocator.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/EncryptAllocator.java
@@ -10,5 +10,5 @@ import java.nio.ByteBuffer;
 
 @FunctionalInterface
 public interface EncryptAllocator {
-    ByteBuffer buffer(int parametersSize, int ciphertextSize);
+    ByteBuffer buffer(int size);
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/ExhaustedDekException.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/ExhaustedDekException.java
@@ -4,16 +4,14 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.filter.encryption.inband;
-
-import io.kroxylicious.filter.encryption.EncryptionException;
+package io.kroxylicious.filter.encryption.dek;
 
 /**
  * Exception indicating that a DEK has been used for
  * encryption too many times.
  * In theory this should never be thrown in practice.
  */
-public class ExhaustedDekException extends EncryptionException {
+public class ExhaustedDekException extends DekException {
     public ExhaustedDekException(String msg) {
         super(msg);
     }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/UnknownCipherSpecException.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/UnknownCipherSpecException.java
@@ -9,7 +9,7 @@ package io.kroxylicious.filter.encryption.dek;
 /**
  * Indicates an attempt to deserialize a persisted reference to a CipherSpec, but the persisted identifier was unknown.
  */
-public class UnknownCipherSpecException extends RuntimeException {
+public class UnknownCipherSpecException extends DekException {
     public UnknownCipherSpecException(String message) {
         super(message);
     }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/FooException.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/FooException.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.inband;
+
+public class FooException extends RuntimeException {
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManager.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.inband;
+
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MutableRecordBatch;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.apache.kafka.common.utils.ByteUtils;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.kroxylicious.filter.encryption.AadSpec;
+import io.kroxylicious.filter.encryption.CipherCode;
+import io.kroxylicious.filter.encryption.DecryptionManager;
+import io.kroxylicious.filter.encryption.EncryptionException;
+import io.kroxylicious.filter.encryption.EncryptionManager;
+import io.kroxylicious.filter.encryption.EncryptionVersion;
+import io.kroxylicious.filter.encryption.EnvelopeEncryptionFilter;
+import io.kroxylicious.filter.encryption.records.BatchAwareMemoryRecordsBuilder;
+import io.kroxylicious.kms.service.Kms;
+import io.kroxylicious.kms.service.Serde;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An implementation of {@link EncryptionManager} and {@link DecryptionManager}
+ * that uses envelope encryption, AES-GCM and stores the KEK id and encrypted DEK
+ * alongside the record ("in-band").
+ * @param <K> The type of KEK id.
+ * @param <E> The type of the encrypted DEK.
+ */
+public class InBandDecryptionManager<K, E> implements DecryptionManager {
+
+    /**
+     * The encryption header. The value is the encryption version that was used to serialize the parcel and the wrapper.
+     */
+    static final String ENCRYPTION_HEADER_NAME = "kroxylicious.io/encryption";
+
+    private final AsyncLoadingCache<E, AesGcmEncryptor> decryptorCache;
+    private final Kms<K, E> kms;
+    private final Serde<E> edekSerde;
+
+    public InBandDecryptionManager(Kms<K, E> kms) {
+        this.kms = kms;
+        this.edekSerde = kms.edekSerde();
+        this.decryptorCache = Caffeine.newBuilder()
+                .buildAsync((edek, executor) -> makeDecryptor(edek));
+    }
+
+    /**
+     * Reads the {@link #ENCRYPTION_HEADER_NAME} header from the record.
+     * @param topicName The topic name.
+     * @param partition The partition.
+     * @param kafkaRecord The record.
+     * @return The encryption header, or null if it's missing (indicating that the record wasn't encrypted).
+     */
+    static EncryptionVersion decryptionVersion(String topicName, int partition, Record kafkaRecord) {
+        for (Header header : kafkaRecord.headers()) {
+            if (ENCRYPTION_HEADER_NAME.equals(header.key())) {
+                byte[] value = header.value();
+                if (value.length != 1) {
+                    throw new EncryptionException("Invalid value for header with key '" + ENCRYPTION_HEADER_NAME + "' "
+                            + "in record at offset " + kafkaRecord.offset()
+                            + " in partition " + partition
+                            + " of topic " + topicName);
+                }
+                return EncryptionVersion.fromCode(value[0]);
+            }
+        }
+        return null;
+    }
+
+    private CompletableFuture<AesGcmEncryptor> makeDecryptor(E edek) {
+        return kms.decryptEdek(edek)
+                .thenApply(AesGcmEncryptor::forDecrypt).toCompletableFuture();
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<MemoryRecords> decrypt(@NonNull String topicName, int partition, @NonNull MemoryRecords records,
+                                                  @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator) {
+        if (records.sizeInBytes() == 0) {
+            // no records to transform, return input without modification
+            return CompletableFuture.completedFuture(records);
+        }
+        List<Integer> batchRecordCounts = InBandEncryptionManager.batchRecordCounts(records);
+        // it is possible to encounter MemoryRecords that have had all their records compacted away, but
+        // the recordbatch metadata still exists. https://kafka.apache.org/documentation/#recordbatch
+        if (batchRecordCounts.stream().allMatch(recordCount -> recordCount == 0)) {
+            return CompletableFuture.completedFuture(records);
+        }
+        Set<E> uniqueEdeks = extractEdeks(topicName, partition, records);
+        CompletionStage<Map<E, AesGcmEncryptor>> decryptors = resolveAll(uniqueEdeks);
+        CompletionStage<BatchAwareMemoryRecordsBuilder> decryptStage = decryptors.thenApply(
+                encryptorMap -> decrypt(topicName, partition, records, new BatchAwareMemoryRecordsBuilder(allocateBufferForDecode(records, bufferAllocator)),
+                        encryptorMap, batchRecordCounts));
+        return decryptStage.thenApply(BatchAwareMemoryRecordsBuilder::build);
+    }
+
+    private CompletionStage<Map<E, AesGcmEncryptor>> resolveAll(Set<E> uniqueEdeks) {
+        CompletionStage<List<Map.Entry<E, AesGcmEncryptor>>> join = EnvelopeEncryptionFilter.join(
+                uniqueEdeks.stream().map(e -> decryptorCache.get(e).thenApply(aesGcmEncryptor -> Map.entry(e, aesGcmEncryptor))).toList());
+        return join.thenApply(entries -> entries.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    private Set<E> extractEdeks(String topicName, int partition, MemoryRecords records) {
+        Set<E> edeks = new HashSet<>();
+        Serde<E> serde = kms.edekSerde();
+        for (Record kafkaRecord : records.records()) {
+            var decryptionVersion = decryptionVersion(topicName, partition, kafkaRecord);
+            if (decryptionVersion == EncryptionVersion.V1) {
+                ByteBuffer wrapper = kafkaRecord.value();
+                var edekLength = ByteUtils.readUnsignedVarint(wrapper);
+                ByteBuffer slice = wrapper.slice(wrapper.position(), edekLength);
+                var edek = serde.deserialize(slice);
+                edeks.add(edek);
+            }
+        }
+        return edeks;
+    }
+
+    @NonNull
+    private BatchAwareMemoryRecordsBuilder decrypt(String topicName,
+                                                   int partition,
+                                                   @NonNull MemoryRecords records,
+                                                   @NonNull BatchAwareMemoryRecordsBuilder builder,
+                                                   @NonNull Map<E, AesGcmEncryptor> encryptorMap,
+                                                   @NonNull List<Integer> batchRecordCounts) {
+        int i = 0;
+        for (MutableRecordBatch batch : records.batches()) {
+            Integer batchRecordCount = batchRecordCounts.get(i++);
+            if (batchRecordCount == 0 || batch.isControlBatch()) {
+                builder.writeBatch(batch);
+            }
+            else {
+                decryptBatch(topicName, partition, builder, encryptorMap, batch);
+            }
+        }
+        return builder;
+    }
+
+    private void decryptBatch(String topicName, int partition, @NonNull BatchAwareMemoryRecordsBuilder builder, @NonNull Map<E, AesGcmEncryptor> encryptorMap,
+                              MutableRecordBatch batch) {
+        builder.addBatchLike(batch);
+        for (Record kafkaRecord : batch) {
+            var decryptionVersion = decryptionVersion(topicName, partition, kafkaRecord);
+            if (decryptionVersion == null) {
+                builder.append(kafkaRecord);
+            }
+            else if (decryptionVersion == EncryptionVersion.V1) {
+                ByteBuffer wrapper = kafkaRecord.value();
+                var edekLength = ByteUtils.readUnsignedVarint(wrapper);
+                ByteBuffer slice = wrapper.slice(wrapper.position(), edekLength);
+                var edek = edekSerde.deserialize(slice);
+                wrapper.position(wrapper.position() + edekLength);
+                AesGcmEncryptor aesGcmEncryptor = encryptorMap.get(edek);
+                if (aesGcmEncryptor == null) {
+                    throw new EncryptionException("no encryptor loaded for edek, " + edek);
+                }
+                decryptRecord(EncryptionVersion.V1, aesGcmEncryptor, wrapper, kafkaRecord, builder);
+            }
+        }
+    }
+
+    private ByteBufferOutputStream allocateBufferForDecode(MemoryRecords memoryRecords, IntFunction<ByteBufferOutputStream> allocator) {
+        int sizeEstimate = memoryRecords.sizeInBytes();
+        return allocator.apply(sizeEstimate);
+    }
+
+    @SuppressWarnings("java:S2445")
+    private void decryptRecord(EncryptionVersion decryptionVersion,
+                               AesGcmEncryptor encryptor,
+                               ByteBuffer wrapper,
+                               Record kafkaRecord,
+                               @NonNull BatchAwareMemoryRecordsBuilder builder) {
+        var aadSpec = AadSpec.fromCode(wrapper.get());
+        ByteBuffer aad = switch (aadSpec) {
+            case NONE -> ByteUtils.EMPTY_BUF;
+        };
+
+        var cipherCode = CipherCode.fromCode(wrapper.get());
+
+        ByteBuffer plaintextParcel;
+        synchronized (encryptor) {
+            plaintextParcel = decryptParcel(wrapper.slice(), encryptor);
+        }
+        Parcel.readParcel(decryptionVersion.parcelVersion(), plaintextParcel, kafkaRecord, (v, h) -> {
+            builder.appendWithOffset(kafkaRecord.offset(), kafkaRecord.timestamp(), kafkaRecord.key(), v, h);
+        });
+    }
+
+    private ByteBuffer decryptParcel(ByteBuffer ciphertextParcel, AesGcmEncryptor encryptor) {
+        ByteBuffer plaintext = ciphertextParcel.duplicate();
+        encryptor.decrypt(ciphertextParcel, plaintext);
+        plaintext.flip();
+        return plaintext;
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
@@ -16,12 +16,13 @@ import java.util.concurrent.Executor;
 import java.util.function.IntFunction;
 import java.util.stream.StreamSupport;
 
+import io.kroxylicious.filter.encryption.dek.ExhaustedDekException;
+
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
-import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.CloseableIterator;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
@@ -7,11 +7,12 @@
 package io.kroxylicious.filter.encryption.inband;
 
 import java.nio.ByteBuffer;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.function.IntFunction;
 import java.util.stream.StreamSupport;
 
@@ -29,15 +30,23 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import io.kroxylicious.filter.encryption.EncryptionManager;
 import io.kroxylicious.filter.encryption.EncryptionScheme;
 import io.kroxylicious.filter.encryption.EncryptionVersion;
+import io.kroxylicious.filter.encryption.dek.CipherSpec;
+import io.kroxylicious.filter.encryption.dek.Dek;
+import io.kroxylicious.filter.encryption.dek.DekManager;
 import io.kroxylicious.filter.encryption.records.BatchAwareMemoryRecordsBuilder;
 import io.kroxylicious.filter.encryption.records.RecordBatchUtils;
-import io.kroxylicious.kms.service.Kms;
-import io.kroxylicious.kms.service.Serde;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
     private static final int MAX_ATTEMPTS = 3;
+
+    private record CacheKey<K>(K kek, CipherSpec cipherSpec) {}
+
+    private static <K> CacheKey<K> cacheKey(EncryptionScheme<K> encryptionScheme) {
+        // TODO Make the cipherSpec configurable on the EncryptionScheme
+        return new CacheKey<>(encryptionScheme.kekId(), CipherSpec.AES_128_GCM_128);
+    }
 
     /**
     * The encryption version used on the produce path.
@@ -45,26 +54,17 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
     * {@link InBandDecryptionManager#ENCRYPTION_HEADER_NAME} header.
     */
     private final EncryptionVersion encryptionVersion;
-    private final Kms<K, E> kms;
+    private final DekManager<K, E> kms;
     private final BufferPool bufferPool;
-    private final Serde edekSerde; // TODO cache expiry, with key descruction
-    private final AsyncLoadingCache<K, KeyContext> keyContextCache;
-    private final long dekTtlNanos;
-    private final int maxEncryptionsPerDek;
+    private final AsyncLoadingCache<CacheKey<K>, Dek<E>> dekCache;
 
-    public InBandEncryptionManager(Kms<K, E> kms,
-                                   BufferPool bufferPool,
-                                   int maxEncryptionsPerDek,
-                                   long dekTtlNanos) {
+    public InBandEncryptionManager(@NonNull DekManager<K, E> kms,
+                                   @NonNull BufferPool bufferPool) {
         this.encryptionVersion = EncryptionVersion.V1; // TODO read from config
-        this.kms = kms;
-        this.bufferPool = bufferPool;
-        this.edekSerde = kms.edekSerde();
-        this.maxEncryptionsPerDek = maxEncryptionsPerDek;
-        this.dekTtlNanos = dekTtlNanos;
-        // TODO This ^^ must be > the maximum size of a batch to avoid an infinite loop
-        this.keyContextCache = Caffeine.newBuilder()
-                .buildAsync((key, executor) -> makeKeyContext(key));
+        this.kms = Objects.requireNonNull(kms);
+        this.bufferPool = Objects.requireNonNull(bufferPool);
+        this.dekCache = Caffeine.newBuilder()
+                .buildAsync(this::requestGenerateDek);
     }
 
     @NonNull
@@ -76,7 +76,7 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
         return sizes;
     }
 
-    private static int recordCount(MutableRecordBatch batch) {
+    private static int recordCount(@NonNull MutableRecordBatch batch) {
         Integer count = batch.countOrNull();
         if (count == null) {
             // for magic <2 count will be null
@@ -91,28 +91,15 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
         return count;
     }
 
-    private CompletionStage<KeyContext> currentDekContext(@NonNull K kekId) {
+    private CompletionStage<Dek<E>> currentDek(@NonNull EncryptionScheme encryptionScheme) {
         // todo should we add some scheduled timeout as well? or should we rely on the KMS to timeout appropriately.
-        return keyContextCache.get(kekId);
+        return dekCache.get(cacheKey(encryptionScheme));
     }
 
-    protected CompletableFuture<KeyContext> makeKeyContext(@NonNull K kekId) {
-        return kms.generateDekPair(kekId)
-                .thenApply(dekPair -> {
-                    E edek = dekPair.edek();
-                    short edekSize = (short) edekSerde.sizeOf(edek);
-                    ByteBuffer serializedEdek = ByteBuffer.allocate(edekSize);
-                    edekSerde.serialize(edek, serializedEdek);
-                    serializedEdek.flip();
-
-                    return new KeyContext(serializedEdek,
-                            System.nanoTime() + dekTtlNanos,
-                            maxEncryptionsPerDek,
-                            // Either we have a different Aes encryptor for each thread
-                            // or we need mutex
-                            // or we externalize the state
-                            AesGcmEncryptor.forEncrypt(new AesGcmIvGenerator(new SecureRandom()), dekPair.dek()));
-                }).toCompletableFuture();
+    private CompletableFuture<Dek<E>> requestGenerateDek(@NonNull CacheKey<K> cacheKey,
+                                                         @NonNull Executor executor) {
+        return kms.generateDek(cacheKey.kek(), cacheKey.cipherSpec())
+                .toCompletableFuture();
     }
 
     @Override
@@ -138,19 +125,20 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                 .thenApply(BatchAwareMemoryRecordsBuilder::build);
     }
 
-    private ByteBufferOutputStream allocateBufferForEncode(MemoryRecords records, IntFunction<ByteBufferOutputStream> bufferAllocator) {
+    private ByteBufferOutputStream allocateBufferForEncode(@NonNull MemoryRecords records,
+                                                           @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator) {
         int sizeEstimate = 2 * records.sizeInBytes();
         // Accurate estimation is tricky without knowing the record sizes
         return bufferAllocator.apply(sizeEstimate);
     }
 
     @SuppressWarnings("java:S2445")
-    private CompletionStage<BatchAwareMemoryRecordsBuilder> attemptEncrypt(String topicName,
+    private CompletionStage<BatchAwareMemoryRecordsBuilder> attemptEncrypt(@NonNull String topicName,
                                                                            int partition,
                                                                            @NonNull EncryptionScheme<K> encryptionScheme,
                                                                            @NonNull MemoryRecords records,
                                                                            int attempt,
-                                                                           List<Integer> batchRecordCounts,
+                                                                           @NonNull List<Integer> batchRecordCounts,
                                                                            @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator) {
         int allRecordsCount = batchRecordCounts.stream().mapToInt(value -> value).sum();
         if (attempt >= MAX_ATTEMPTS) {
@@ -158,25 +146,22 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                     new RequestNotSatisfiable("failed to reserve an EDEK to encrypt " + allRecordsCount + " records for topic " + topicName + " partition "
                             + partition + " after " + attempt + " attempts"));
         }
-        return currentDekContext(encryptionScheme.kekId()).thenCompose(keyContext -> {
-            synchronized (keyContext) {
-                // if it's not alive we know a previous encrypt call has removed this stage from the cache and fall through to retry encrypt
-                if (!keyContext.isDestroyed()) {
-                    if (!keyContext.hasAtLeastRemainingEncryptions(allRecordsCount)) {
-                        // remove the key context from the cache, then call encrypt again to drive caffeine to recreate it
-                        rotateKeyContext(encryptionScheme, keyContext);
-                    }
-                    else {
-                        try {
-                            BatchAwareMemoryRecordsBuilder encrypt = encryptBatches(encryptionScheme, records, keyContext, bufferAllocator);
-                            return CompletableFuture.completedFuture(encrypt);
-                        }
-                        catch (Exception e) {
-                            return CompletableFuture.failedFuture(e);
-                        }
-                    }
+        return currentDek(encryptionScheme).thenCompose(dek -> {
+            // if it's not alive we know a previous encrypt call has removed this stage from the cache and fall through to retry encrypt
+            if (!dek.isDestroyed()) {
+                try (Dek<E>.Encryptor encryptor = dek.encryptor(allRecordsCount)) {
+                    BatchAwareMemoryRecordsBuilder encrypt = encryptBatches(encryptionScheme, records, encryptor, bufferAllocator);
+                    return CompletableFuture.completedFuture(encrypt);
+                }
+                catch (ExhaustedDekException e) {
+                    rotateKeyContext(encryptionScheme, dek);
+                    // fall through to recursive call below...
+                }
+                catch (Exception e) {
+                    return CompletableFuture.failedFuture(e);
                 }
             }
+            // recurse, incrementing the attempt number
             return attemptEncrypt(topicName, partition, encryptionScheme, records, attempt + 1, batchRecordCounts, bufferAllocator);
         });
     }
@@ -184,17 +169,19 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
     @NonNull
     private BatchAwareMemoryRecordsBuilder encryptBatches(@NonNull EncryptionScheme<K> encryptionScheme,
                                                           @NonNull MemoryRecords memoryRecords,
-                                                          @NonNull KeyContext keyContext,
+                                                          @NonNull Dek.Encryptor encryptor,
                                                           @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator) {
         BatchAwareMemoryRecordsBuilder builder = new BatchAwareMemoryRecordsBuilder(allocateBufferForEncode(memoryRecords, bufferAllocator));
         for (MutableRecordBatch batch : memoryRecords.batches()) {
-            maybeEncryptBatch(encryptionScheme, keyContext, batch, builder);
+            maybeEncryptBatch(encryptionScheme, encryptor, batch, builder);
         }
         return builder;
     }
 
-    private void maybeEncryptBatch(@NonNull EncryptionScheme<K> encryptionScheme, @NonNull KeyContext keyContext, MutableRecordBatch batch,
-                                   BatchAwareMemoryRecordsBuilder builder) {
+    private void maybeEncryptBatch(@NonNull EncryptionScheme<K> encryptionScheme,
+                                   @NonNull Dek.Encryptor encryptor,
+                                   @NonNull MutableRecordBatch batch,
+                                   @NonNull BatchAwareMemoryRecordsBuilder builder) {
         if (batch.isControlBatch()) {
             builder.writeBatch(batch);
         }
@@ -221,7 +208,7 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                 ByteBuffer wrapperBuffer = bufferPool.acquire(maxWrapperSize);
                 try {
                     RecordBatchUtils.toMemoryRecords(batch,
-                            new RecordEncryptor<>(encryptionVersion, encryptionScheme, keyContext, parcelBuffer, wrapperBuffer),
+                            new RecordEncryptor<>(encryptionVersion, encryptionScheme, encryptor, kms.edekSerde(), parcelBuffer, wrapperBuffer),
                             builder);
                 }
                 finally {
@@ -232,15 +219,14 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                         bufferPool.release(parcelBuffer);
                     }
                 }
-                keyContext.recordEncryptions(records.size());
+                // keyContext.recordEncryptions(records.size());
             }
         }
     }// this must only be called while holding the lock on this keycontext
 
-    private void rotateKeyContext(@NonNull EncryptionScheme<K> encryptionScheme, KeyContext keyContext) {
-        keyContext.destroy();
-        K kekId = encryptionScheme.kekId();
-        keyContextCache.synchronous().invalidate(kekId);
+    private void rotateKeyContext(@NonNull EncryptionScheme<K> encryptionScheme, Dek<E> dek) {
+        dek.destroyForEncrypt();
+        dekCache.synchronous().invalidate(cacheKey(encryptionScheme));
     }
 
     private int sizeOfWrapper(KeyContext keyContext, int parcelSize) {

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
@@ -9,17 +9,12 @@ package io.kroxylicious.filter.encryption.inband;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.IntFunction;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.Record;
@@ -31,14 +26,9 @@ import org.apache.kafka.common.utils.CloseableIterator;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
-import io.kroxylicious.filter.encryption.AadSpec;
-import io.kroxylicious.filter.encryption.CipherCode;
-import io.kroxylicious.filter.encryption.DecryptionManager;
-import io.kroxylicious.filter.encryption.EncryptionException;
 import io.kroxylicious.filter.encryption.EncryptionManager;
 import io.kroxylicious.filter.encryption.EncryptionScheme;
 import io.kroxylicious.filter.encryption.EncryptionVersion;
-import io.kroxylicious.filter.encryption.EnvelopeEncryptionFilter;
 import io.kroxylicious.filter.encryption.records.BatchAwareMemoryRecordsBuilder;
 import io.kroxylicious.filter.encryption.records.RecordBatchUtils;
 import io.kroxylicious.kms.service.Kms;
@@ -46,52 +36,59 @@ import io.kroxylicious.kms.service.Serde;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-/**
- * An implementation of {@link EncryptionManager} and {@link DecryptionManager}
- * that uses envelope encryption, AES-GCM and stores the KEK id and encrypted DEK
- * alongside the record ("in-band").
- * @param <K> The type of KEK id.
- * @param <E> The type of the encrypted DEK.
- */
-public class InBandKeyManager<K, E> implements EncryptionManager<K>, DecryptionManager {
-
+public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
     private static final int MAX_ATTEMPTS = 3;
 
     /**
-     * The encryption header. The value is the encryption version that was used to serialize the parcel and the wrapper.
-     */
-    static final String ENCRYPTION_HEADER_NAME = "kroxylicious.io/encryption";
-
-    /**
-     * The encryption version used on the produce path.
-     * Note that the encryption version used on the fetch path is read from the
-     * {@link #ENCRYPTION_HEADER_NAME} header.
-     */
+    * The encryption version used on the produce path.
+    * Note that the encryption version used on the fetch path is read from the
+    * {@link InBandDecryptionManager#ENCRYPTION_HEADER_NAME} header.
+    */
     private final EncryptionVersion encryptionVersion;
-
     private final Kms<K, E> kms;
     private final BufferPool bufferPool;
-    private final Serde<E> edekSerde;
-    // TODO cache expiry, with key descruction
+    private final Serde edekSerde; // TODO cache expiry, with key descruction
     private final AsyncLoadingCache<K, KeyContext> keyContextCache;
-    private final AsyncLoadingCache<E, AesGcmEncryptor> decryptorCache;
     private final long dekTtlNanos;
     private final int maxEncryptionsPerDek;
 
-    public InBandKeyManager(Kms<K, E> kms,
-                            BufferPool bufferPool,
-                            int maxEncryptionsPerDek) {
+    public InBandEncryptionManager(Kms<K, E> kms,
+                                   BufferPool bufferPool,
+                                   int maxEncryptionsPerDek,
+                                   long dekTtlNanos) {
+        this.encryptionVersion = EncryptionVersion.V1; // TODO read from config
         this.kms = kms;
         this.bufferPool = bufferPool;
         this.edekSerde = kms.edekSerde();
-        this.dekTtlNanos = 5_000_000_000L;
         this.maxEncryptionsPerDek = maxEncryptionsPerDek;
+        this.dekTtlNanos = dekTtlNanos;
         // TODO This ^^ must be > the maximum size of a batch to avoid an infinite loop
         this.keyContextCache = Caffeine.newBuilder()
                 .buildAsync((key, executor) -> makeKeyContext(key));
-        this.decryptorCache = Caffeine.newBuilder()
-                .buildAsync((edek, executor) -> makeDecryptor(edek));
-        this.encryptionVersion = EncryptionVersion.V1; // TODO read from config
+    }
+
+    @NonNull
+    static List<Integer> batchRecordCounts(@NonNull MemoryRecords records) {
+        List<Integer> sizes = new ArrayList<>();
+        for (MutableRecordBatch batch : records.batches()) {
+            sizes.add(InBandEncryptionManager.recordCount(batch));
+        }
+        return sizes;
+    }
+
+    private static int recordCount(MutableRecordBatch batch) {
+        Integer count = batch.countOrNull();
+        if (count == null) {
+            // for magic <2 count will be null
+            CloseableIterator<Record> iterator = batch.skipKeyValueIterator(BufferSupplier.NO_CACHING);
+            int c = 0;
+            while (iterator.hasNext()) {
+                c++;
+                iterator.next();
+            }
+            count = c;
+        }
+        return count;
     }
 
     private CompletionStage<KeyContext> currentDekContext(@NonNull K kekId) {
@@ -99,7 +96,7 @@ public class InBandKeyManager<K, E> implements EncryptionManager<K>, DecryptionM
         return keyContextCache.get(kekId);
     }
 
-    private CompletableFuture<KeyContext> makeKeyContext(@NonNull K kekId) {
+    protected CompletableFuture<KeyContext> makeKeyContext(@NonNull K kekId) {
         return kms.generateDekPair(kekId)
                 .thenApply(dekPair -> {
                     E edek = dekPair.edek();
@@ -131,7 +128,7 @@ public class InBandKeyManager<K, E> implements EncryptionManager<K>, DecryptionM
             return CompletableFuture.completedFuture(records);
         }
 
-        List<Integer> batchRecordCounts = batchRecordCounts(records);
+        List<Integer> batchRecordCounts = InBandEncryptionManager.batchRecordCounts(records);
         // it is possible to encounter MemoryRecords that have had all their records compacted away, but
         // the recordbatch metadata still exists. https://kafka.apache.org/documentation/#recordbatch
         if (batchRecordCounts.stream().allMatch(size -> size == 0)) {
@@ -139,30 +136,6 @@ public class InBandKeyManager<K, E> implements EncryptionManager<K>, DecryptionM
         }
         return attemptEncrypt(topicName, partition, encryptionScheme, records, 0, batchRecordCounts, bufferAllocator)
                 .thenApply(BatchAwareMemoryRecordsBuilder::build);
-    }
-
-    @NonNull
-    private static List<Integer> batchRecordCounts(@NonNull MemoryRecords records) {
-        List<Integer> sizes = new ArrayList<>();
-        for (MutableRecordBatch batch : records.batches()) {
-            sizes.add(recordCount(batch));
-        }
-        return sizes;
-    }
-
-    private static int recordCount(MutableRecordBatch batch) {
-        Integer count = batch.countOrNull();
-        if (count == null) {
-            // for magic <2 count will be null
-            CloseableIterator<Record> iterator = batch.skipKeyValueIterator(BufferSupplier.NO_CACHING);
-            int c = 0;
-            while (iterator.hasNext()) {
-                c++;
-                iterator.next();
-            }
-            count = c;
-        }
-        return count;
     }
 
     private ByteBufferOutputStream allocateBufferForEncode(MemoryRecords records, IntFunction<ByteBufferOutputStream> bufferAllocator) {
@@ -262,9 +235,8 @@ public class InBandKeyManager<K, E> implements EncryptionManager<K>, DecryptionM
                 keyContext.recordEncryptions(records.size());
             }
         }
-    }
+    }// this must only be called while holding the lock on this keycontext
 
-    // this must only be called while holding the lock on this keycontext
     private void rotateKeyContext(@NonNull EncryptionScheme<K> encryptionScheme, KeyContext keyContext) {
         keyContext.destroy();
         K kekId = encryptionScheme.kekId();
@@ -280,154 +252,4 @@ public class InBandKeyManager<K, E> implements EncryptionManager<K>, DecryptionM
                 + keyContext.encodedSize(parcelSize);
 
     }
-
-    /**
-     * Reads the {@link #ENCRYPTION_HEADER_NAME} header from the record.
-     * @param topicName The topic name.
-     * @param partition The partition.
-     * @param kafkaRecord The record.
-     * @return The encryption header, or null if it's missing (indicating that the record wasn't encrypted).
-     */
-    static EncryptionVersion decryptionVersion(String topicName, int partition, Record kafkaRecord) {
-        for (Header header : kafkaRecord.headers()) {
-            if (ENCRYPTION_HEADER_NAME.equals(header.key())) {
-                byte[] value = header.value();
-                if (value.length != 1) {
-                    throw new EncryptionException("Invalid value for header with key '" + ENCRYPTION_HEADER_NAME + "' "
-                            + "in record at offset " + kafkaRecord.offset()
-                            + " in partition " + partition
-                            + " of topic " + topicName);
-                }
-                return EncryptionVersion.fromCode(value[0]);
-            }
-        }
-        return null;
-    }
-
-    private CompletableFuture<AesGcmEncryptor> makeDecryptor(E edek) {
-        return kms.decryptEdek(edek)
-                .thenApply(AesGcmEncryptor::forDecrypt).toCompletableFuture();
-    }
-
-    @NonNull
-    @Override
-    public CompletionStage<MemoryRecords> decrypt(@NonNull String topicName, int partition, @NonNull MemoryRecords records,
-                                                  @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator) {
-        if (records.sizeInBytes() == 0) {
-            // no records to transform, return input without modification
-            return CompletableFuture.completedFuture(records);
-        }
-        List<Integer> batchRecordCounts = batchRecordCounts(records);
-        // it is possible to encounter MemoryRecords that have had all their records compacted away, but
-        // the recordbatch metadata still exists. https://kafka.apache.org/documentation/#recordbatch
-        if (batchRecordCounts.stream().allMatch(recordCount -> recordCount == 0)) {
-            return CompletableFuture.completedFuture(records);
-        }
-        Set<E> uniqueEdeks = extractEdeks(topicName, partition, records);
-        CompletionStage<Map<E, AesGcmEncryptor>> decryptors = resolveAll(uniqueEdeks);
-        CompletionStage<BatchAwareMemoryRecordsBuilder> decryptStage = decryptors.thenApply(
-                encryptorMap -> decrypt(topicName, partition, records, new BatchAwareMemoryRecordsBuilder(allocateBufferForDecode(records, bufferAllocator)),
-                        encryptorMap, batchRecordCounts));
-        return decryptStage.thenApply(BatchAwareMemoryRecordsBuilder::build);
-    }
-
-    private CompletionStage<Map<E, AesGcmEncryptor>> resolveAll(Set<E> uniqueEdeks) {
-        CompletionStage<List<Map.Entry<E, AesGcmEncryptor>>> join = EnvelopeEncryptionFilter.join(
-                uniqueEdeks.stream().map(e -> decryptorCache.get(e).thenApply(aesGcmEncryptor -> Map.entry(e, aesGcmEncryptor))).toList());
-        return join.thenApply(entries -> entries.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    }
-
-    private Set<E> extractEdeks(String topicName, int partition, MemoryRecords records) {
-        Set<E> edeks = new HashSet<>();
-        Serde<E> serde = kms.edekSerde();
-        for (Record kafkaRecord : records.records()) {
-            var decryptionVersion = decryptionVersion(topicName, partition, kafkaRecord);
-            if (decryptionVersion == EncryptionVersion.V1) {
-                ByteBuffer wrapper = kafkaRecord.value();
-                var edekLength = ByteUtils.readUnsignedVarint(wrapper);
-                ByteBuffer slice = wrapper.slice(wrapper.position(), edekLength);
-                var edek = serde.deserialize(slice);
-                edeks.add(edek);
-            }
-        }
-        return edeks;
-    }
-
-    @NonNull
-    private BatchAwareMemoryRecordsBuilder decrypt(String topicName,
-                                                   int partition,
-                                                   @NonNull MemoryRecords records,
-                                                   @NonNull BatchAwareMemoryRecordsBuilder builder,
-                                                   @NonNull Map<E, AesGcmEncryptor> encryptorMap,
-                                                   @NonNull List<Integer> batchRecordCounts) {
-        int i = 0;
-        for (MutableRecordBatch batch : records.batches()) {
-            Integer batchRecordCount = batchRecordCounts.get(i++);
-            if (batchRecordCount == 0 || batch.isControlBatch()) {
-                builder.writeBatch(batch);
-            }
-            else {
-                decryptBatch(topicName, partition, builder, encryptorMap, batch);
-            }
-        }
-        return builder;
-    }
-
-    private void decryptBatch(String topicName, int partition, @NonNull BatchAwareMemoryRecordsBuilder builder, @NonNull Map<E, AesGcmEncryptor> encryptorMap,
-                              MutableRecordBatch batch) {
-        builder.addBatchLike(batch);
-        for (Record kafkaRecord : batch) {
-            var decryptionVersion = decryptionVersion(topicName, partition, kafkaRecord);
-            if (decryptionVersion == null) {
-                builder.append(kafkaRecord);
-            }
-            else if (decryptionVersion == EncryptionVersion.V1) {
-                ByteBuffer wrapper = kafkaRecord.value();
-                var edekLength = ByteUtils.readUnsignedVarint(wrapper);
-                ByteBuffer slice = wrapper.slice(wrapper.position(), edekLength);
-                var edek = edekSerde.deserialize(slice);
-                wrapper.position(wrapper.position() + edekLength);
-                AesGcmEncryptor aesGcmEncryptor = encryptorMap.get(edek);
-                if (aesGcmEncryptor == null) {
-                    throw new EncryptionException("no encryptor loaded for edek, " + edek);
-                }
-                decryptRecord(EncryptionVersion.V1, aesGcmEncryptor, wrapper, kafkaRecord, builder);
-            }
-        }
-    }
-
-    private ByteBufferOutputStream allocateBufferForDecode(MemoryRecords memoryRecords, IntFunction<ByteBufferOutputStream> allocator) {
-        int sizeEstimate = memoryRecords.sizeInBytes();
-        return allocator.apply(sizeEstimate);
-    }
-
-    @SuppressWarnings("java:S2445")
-    private void decryptRecord(EncryptionVersion decryptionVersion,
-                               AesGcmEncryptor encryptor,
-                               ByteBuffer wrapper,
-                               Record kafkaRecord,
-                               @NonNull BatchAwareMemoryRecordsBuilder builder) {
-        var aadSpec = AadSpec.fromCode(wrapper.get());
-        ByteBuffer aad = switch (aadSpec) {
-            case NONE -> ByteUtils.EMPTY_BUF;
-        };
-
-        var cipherCode = CipherCode.fromCode(wrapper.get());
-
-        ByteBuffer plaintextParcel;
-        synchronized (encryptor) {
-            plaintextParcel = decryptParcel(wrapper.slice(), encryptor);
-        }
-        Parcel.readParcel(decryptionVersion.parcelVersion(), plaintextParcel, kafkaRecord, (v, h) -> {
-            builder.appendWithOffset(kafkaRecord.offset(), kafkaRecord.timestamp(), kafkaRecord.key(), v, h);
-        });
-    }
-
-    private ByteBuffer decryptParcel(ByteBuffer ciphertextParcel, AesGcmEncryptor encryptor) {
-        ByteBuffer plaintext = ciphertextParcel.duplicate();
-        encryptor.decrypt(ciphertextParcel, plaintext);
-        plaintext.flip();
-        return plaintext;
-    }
-
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
@@ -225,7 +225,7 @@ public class InBandKeyManager<K, E> implements KeyManager<K> {
         }
         else {
             List<Record> records = StreamSupport.stream(batch.spliterator(), false).toList();
-            if (records.size() == 0) {
+            if (records.isEmpty()) {
                 builder.writeBatch(batch);
             }
             else {

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
@@ -33,11 +33,12 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.kroxylicious.filter.encryption.AadSpec;
 import io.kroxylicious.filter.encryption.CipherCode;
+import io.kroxylicious.filter.encryption.DecryptionManager;
 import io.kroxylicious.filter.encryption.EncryptionException;
+import io.kroxylicious.filter.encryption.EncryptionManager;
 import io.kroxylicious.filter.encryption.EncryptionScheme;
 import io.kroxylicious.filter.encryption.EncryptionVersion;
 import io.kroxylicious.filter.encryption.EnvelopeEncryptionFilter;
-import io.kroxylicious.filter.encryption.KeyManager;
 import io.kroxylicious.filter.encryption.records.BatchAwareMemoryRecordsBuilder;
 import io.kroxylicious.filter.encryption.records.RecordBatchUtils;
 import io.kroxylicious.kms.service.Kms;
@@ -46,12 +47,13 @@ import io.kroxylicious.kms.service.Serde;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * An implementation of {@link KeyManager} that uses envelope encryption, AES-GCM and stores the KEK id and encrypted DEK
+ * An implementation of {@link EncryptionManager} and {@link DecryptionManager}
+ * that uses envelope encryption, AES-GCM and stores the KEK id and encrypted DEK
  * alongside the record ("in-band").
  * @param <K> The type of KEK id.
  * @param <E> The type of the encrypted DEK.
  */
-public class InBandKeyManager<K, E> implements KeyManager<K> {
+public class InBandKeyManager<K, E> implements EncryptionManager<K>, DecryptionManager {
 
     private static final int MAX_ATTEMPTS = 3;
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -14,10 +14,10 @@ import javax.annotation.concurrent.NotThreadSafe;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 
-import io.kroxylicious.filter.encryption.dek.ExhaustedDekException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.filter.encryption.dek.ExhaustedDekException;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -14,6 +14,8 @@ import javax.annotation.concurrent.NotThreadSafe;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 
+import io.kroxylicious.filter.encryption.dek.ExhaustedDekException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -65,7 +65,7 @@ final class KeyContext implements Destroyable {
     }
 
     public void recordEncryptions(int numEncryptions) {
-        if (numEncryptions <= 0) {
+        if (numEncryptions < 0) {
             throw new IllegalArgumentException();
         }
         remainingEncryptions -= numEncryptions;

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/Parcel.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/Parcel.java
@@ -67,7 +67,7 @@ public class Parcel {
                 Header[] usedHeaders;
                 if (parcelledHeaders == ABSENT_HEADERS) {
                     if (existingHeaders.length > 0
-                            && InBandKeyManager.ENCRYPTION_HEADER_NAME.equals(existingHeaders[0].key())) {
+                            && InBandDecryptionManager.ENCRYPTION_HEADER_NAME.equals(existingHeaders[0].key())) {
                         // need to remove the encryption header
                         usedHeaders = new Header[existingHeaders.length - 1];
                         System.arraycopy(existingHeaders, 1, usedHeaders, 0, usedHeaders.length);

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
@@ -92,13 +92,9 @@ public class RecordBatchUtils {
         Objects.requireNonNull(recordBatch);
         Objects.requireNonNull(mapper);
         Objects.requireNonNull(builder);
-        // List<Runnable> closers = new ArrayList<>();
         try (Stream<Record> recordStream = recordStream(recordBatch)) {
             return recordStream
                     .collect(toMemoryRecordsCollector(recordBatch, mapper, builder));
-        }
-        finally {
-            // closers.forEach(Runnable::run);
         }
     }
 
@@ -114,7 +110,6 @@ public class RecordBatchUtils {
             public Supplier<BatchAwareMemoryRecordsBuilder> supplier() {
                 return () -> {
                     BatchAwareMemoryRecordsBuilder batchAwareMemoryRecordsBuilder = builder;
-                    // onClose.accept(batchAwareMemoryRecordsBuilder::close);
                     return batchAwareMemoryRecordsBuilder.addBatchLike(recordBatch);
                 };
             }

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
@@ -79,7 +79,10 @@ class EnvelopeEncryptionFilterTest {
     private static final byte[] ENCRYPTED_MESSAGE_BYTES = "xslkajfd;ljsaefjjKLDJlkDSJFLJK';,kSDKF'".getBytes(UTF_8);
 
     @Mock(strictness = LENIENT)
-    KeyManager<String> keyManager;
+    EncryptionManager<String> encryptionManager;
+
+    @Mock(strictness = LENIENT)
+    DecryptionManager decryptionManager;
 
     @Mock(strictness = LENIENT)
     TopicNameBasedKekSelector<String> kekSelector;
@@ -120,11 +123,11 @@ class EnvelopeEncryptionFilterTest {
             return CompletableFuture.completedFuture(copy);
         });
 
-        when(keyManager.encrypt(any(), anyInt(), any(), any(), any())).thenReturn(CompletableFuture.completedFuture(RecordTestUtils.singleElementMemoryRecords("key", "value")));
+        when(encryptionManager.encrypt(any(), anyInt(), any(), any(), any())).thenReturn(CompletableFuture.completedFuture(RecordTestUtils.singleElementMemoryRecords("key", "value")));
 
-        when(keyManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.completedFuture(RecordTestUtils.singleElementMemoryRecords("decrypt", "decrypt")));
+        when(decryptionManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.completedFuture(RecordTestUtils.singleElementMemoryRecords("decrypt", "decrypt")));
 
-        encryptionFilter = new EnvelopeEncryptionFilter<>(keyManager, kekSelector);
+        encryptionFilter = new EnvelopeEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector);
     }
 
     @Test
@@ -138,7 +141,7 @@ class EnvelopeEncryptionFilterTest {
         encryptionFilter.onProduceRequest(ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), produceRequestData, context);
 
         // Then
-        verify(keyManager, never()).encrypt(any(), anyInt(), any(), any(), any());
+        verify(encryptionManager, never()).encrypt(any(), anyInt(), any(), any(), any());
     }
 
     @Test
@@ -152,7 +155,7 @@ class EnvelopeEncryptionFilterTest {
         encryptionFilter.onProduceRequest(ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), produceRequestData, context);
 
         // Then
-        verify(keyManager).encrypt(any(), anyInt(), any(), any(), any());
+        verify(encryptionManager).encrypt(any(), anyInt(), any(), any(), any());
     }
 
     @Test
@@ -169,7 +172,7 @@ class EnvelopeEncryptionFilterTest {
         encryptionFilter.onProduceRequest(ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), produceRequestData, context);
 
         // Then
-        verify(keyManager).encrypt(any(), anyInt(), any(),
+        verify(encryptionManager).encrypt(any(), anyInt(), any(),
                 argThat(records -> assertThat(records.records())
                         .hasSize(1)
                         .allSatisfy(record -> assertThat(record.value()).isEqualTo(ByteBuffer.wrap(HELLO_CIPHER_WORLD)))),
@@ -200,7 +203,7 @@ class EnvelopeEncryptionFilterTest {
                 .setPartitions(List.of(new PartitionData().setRecords(makeRecord(ENCRYPTED_MESSAGE_BYTES)))));
 
         MemoryRecords decryptedRecords = RecordTestUtils.singleElementMemoryRecords("key", "value");
-        when(keyManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.completedFuture(decryptedRecords));
+        when(decryptionManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.completedFuture(decryptedRecords));
 
         // When
         encryptionFilter.onFetchResponse(FetchResponseData.HIGHEST_SUPPORTED_VERSION,

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import io.kroxylicious.filter.encryption.inband.ExhaustedDekException;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryEdek;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService;
 import io.kroxylicious.kms.service.Serde;

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
@@ -76,10 +76,10 @@ class DekManagerTest {
         ByteBuffer[] params = new ByteBuffer[1];
         InMemoryEdek edek;
         try (Dek<InMemoryEdek>.Encryptor encryptor = dek.encryptor(1)) {
+            encryptor.preEncrypt(size -> params[0] = ByteBuffer.allocate(size));
             encryptor.encrypt(plaintext,
                     aad,
-                    (x, y) -> params[0] = ByteBuffer.allocate(x),
-                    (x, y) -> ciphertext[0] = ByteBuffer.allocate(y));
+                    size -> ciphertext[0] = ByteBuffer.allocate(size));
             edek = encryptor.edek();
         }
         var edekBuffer = ByteBuffer.allocate(1024);

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 
 import io.kroxylicious.filter.encryption.EncryptionException;
-import io.kroxylicious.filter.encryption.inband.ExhaustedDekException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManagerTest.java
@@ -44,6 +44,7 @@ import org.mockito.stubbing.Answer;
 
 import io.kroxylicious.filter.encryption.EncryptionScheme;
 import io.kroxylicious.filter.encryption.RecordField;
+import io.kroxylicious.filter.encryption.dek.DekManager;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryEdek;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryKms;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService;
@@ -906,7 +907,7 @@ class InBandDecryptionManagerTest {
 
     @NonNull
     private static InBandEncryptionManager<UUID, InMemoryEdek> createEncryptionManager(InMemoryKms kms, int maxEncryptionsPerDek) {
-        return new InBandEncryptionManager<>(kms, BufferPool.allocating(), maxEncryptionsPerDek, 5_000_000_000L);
+        return new InBandEncryptionManager<>(new DekManager<UUID, InMemoryEdek>(ignored -> kms, null, maxEncryptionsPerDek), BufferPool.allocating());
     }
 
     @NonNull

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManagerTest.java
@@ -62,7 +62,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
-class InBandKeyManagerTest {
+class InBandDecryptionManagerTest {
 
     private static final String ARBITRARY_KEY = "key";
     private static final String ARBITRARY_KEY_2 = "key2";
@@ -86,7 +86,8 @@ class InBandKeyManagerTest {
     @Test
     void shouldEncryptRecordValue() {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         var kekId = kms.generateKey();
 
@@ -95,7 +96,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record);
-        assertThat(doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), initial, encrypted))
+        assertThat(doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), initial, encrypted))
                 .isCompleted();
         assertThat(encrypted.iterator())
                 .toIterable()
@@ -106,7 +107,7 @@ class InBandKeyManagerTest {
         List<Record> decrypted = new ArrayList<>();
         String topic = "foo";
         int partition = 1;
-        assertThat(doDecrypt(km, topic, partition, encrypted, decrypted))
+        assertThat(doDecrypt(decryptionManager, topic, partition, encrypted, decrypted))
                 .isCompleted();
 
         assertThat(decrypted.iterator())
@@ -121,7 +122,7 @@ class InBandKeyManagerTest {
         // given
         InMemoryKms kms = getInMemoryKms();
         EncryptionScheme<UUID> scheme = createScheme(kms);
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
 
         MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 1L, CompressionType.GZIP, TimestampType.CREATE_TIME, 2L,
                 3L,
@@ -137,7 +138,7 @@ class InBandKeyManagerTest {
         MemoryRecords records = RecordTestUtils.memoryRecords(firstBatch, secondBatch);
 
         // when
-        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(km, scheme, records));
+        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(encryptionManager, scheme, records));
 
         // then
         MemoryRecordsAssert encryptedAssert = MemoryRecordsAssert.assertThat(encrypted);
@@ -151,7 +152,8 @@ class InBandKeyManagerTest {
         // given
         InMemoryKms kms = getInMemoryKms();
         EncryptionScheme<UUID> scheme = createScheme(kms);
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 1L, CompressionType.GZIP, TimestampType.CREATE_TIME, 2L,
                 3L,
@@ -165,10 +167,10 @@ class InBandKeyManagerTest {
                         StandardCharsets.UTF_8),
                 ARBITRARY_VALUE_2.getBytes(StandardCharsets.UTF_8));
         MemoryRecords records = RecordTestUtils.memoryRecords(firstBatch, secondBatch);
-        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(km, scheme, records));
+        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(encryptionManager, scheme, records));
 
         // when
-        MemoryRecords decrypted = assertImmediateSuccessAndGet(decrypt(km, encrypted));
+        MemoryRecords decrypted = assertImmediateSuccessAndGet(decrypt(decryptionManager, encrypted));
 
         // then
         MemoryRecordsAssert decryptedAssert = MemoryRecordsAssert.assertThat(decrypted);
@@ -182,7 +184,7 @@ class InBandKeyManagerTest {
         // given
         InMemoryKms kms = getInMemoryKms();
         EncryptionScheme<UUID> scheme = createScheme(kms);
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
 
         MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(1L, ARBITRARY_KEY, ARBITRARY_VALUE, ABSENT_HEADERS);
         MutableRecordBatch controlBatch = RecordTestUtils.abortTransactionControlBatch(2);
@@ -190,7 +192,7 @@ class InBandKeyManagerTest {
         MemoryRecords records = RecordTestUtils.memoryRecords(firstBatch, controlBatch);
 
         // when
-        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(km, scheme, records));
+        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(encryptionManager, scheme, records));
 
         // then
         MemoryRecordsAssert encryptedAssert = MemoryRecordsAssert.assertThat(encrypted);
@@ -204,16 +206,17 @@ class InBandKeyManagerTest {
         // given
         InMemoryKms kms = getInMemoryKms();
         EncryptionScheme<UUID> scheme = createScheme(kms);
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(1L, ARBITRARY_KEY, ARBITRARY_VALUE, ABSENT_HEADERS);
         MutableRecordBatch controlBatch = RecordTestUtils.abortTransactionControlBatch(2);
         Record controlRecord = controlBatch.iterator().next();
         MemoryRecords records = RecordTestUtils.memoryRecords(firstBatch, controlBatch);
-        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(km, scheme, records));
+        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(encryptionManager, scheme, records));
 
         // when
-        MemoryRecords decrypted = assertImmediateSuccessAndGet(decrypt(km, encrypted));
+        MemoryRecords decrypted = assertImmediateSuccessAndGet(decrypt(decryptionManager, encrypted));
 
         // then
         MemoryRecordsAssert decryptedAssert = MemoryRecordsAssert.assertThat(decrypted);
@@ -227,14 +230,14 @@ class InBandKeyManagerTest {
         // given
         InMemoryKms kms = getInMemoryKms();
         EncryptionScheme<UUID> scheme = createScheme(kms);
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
 
         MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(1L, ARBITRARY_KEY, ARBITRARY_VALUE, ABSENT_HEADERS);
         MutableRecordBatch emptyBatch = RecordTestUtils.recordBatchWithAllRecordsRemoved(2L);
         MemoryRecords records = RecordTestUtils.memoryRecords(firstBatch, emptyBatch);
 
         // when
-        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(km, scheme, records));
+        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(encryptionManager, scheme, records));
 
         // then
         MemoryRecordsAssert encryptedAssert = MemoryRecordsAssert.assertThat(encrypted);
@@ -248,15 +251,16 @@ class InBandKeyManagerTest {
         // given
         InMemoryKms kms = getInMemoryKms();
         EncryptionScheme<UUID> scheme = createScheme(kms);
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(1L, ARBITRARY_KEY, ARBITRARY_VALUE, ABSENT_HEADERS);
         MutableRecordBatch emptyBatch = RecordTestUtils.recordBatchWithAllRecordsRemoved(2L);
         MemoryRecords records = RecordTestUtils.memoryRecords(firstBatch, emptyBatch);
-        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(km, scheme, records));
+        MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(encryptionManager, scheme, records));
 
         // when
-        MemoryRecords decrypted = assertImmediateSuccessAndGet(decrypt(km, encrypted));
+        MemoryRecords decrypted = assertImmediateSuccessAndGet(decrypt(decryptionManager, encrypted));
 
         // then
         MemoryRecordsAssert decryptedAssert = MemoryRecordsAssert.assertThat(decrypted);
@@ -266,14 +270,14 @@ class InBandKeyManagerTest {
     }
 
     @NonNull
-    private static CompletionStage<Void> doDecrypt(InBandKeyManager<UUID, InMemoryEdek> km, String topic, int partition, List<Record> encrypted,
+    private static CompletionStage<Void> doDecrypt(InBandDecryptionManager<UUID, InMemoryEdek> km, String topic, int partition, List<Record> encrypted,
                                                    List<Record> decrypted) {
         return km.decrypt(topic, partition, RecordTestUtils.memoryRecords(encrypted), ByteBufferOutputStream::new)
                 .thenAccept(records -> records.records().forEach(decrypted::add));
     }
 
     @NonNull
-    private static CompletionStage<Void> doEncrypt(InBandKeyManager<UUID, InMemoryEdek> keyManager,
+    private static CompletionStage<Void> doEncrypt(InBandEncryptionManager<UUID, InMemoryEdek> keyManager,
                                                    String topic,
                                                    int partition,
                                                    EncryptionScheme<UUID> scheme,
@@ -289,7 +293,8 @@ class InBandKeyManagerTest {
     @Test
     void shouldTolerateEncryptingAndDecryptingEmptyRecordValue() {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         var kekId = kms.generateKey();
 
@@ -298,14 +303,14 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record);
-        assertThat(doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), initial, encrypted))
+        assertThat(doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), initial, encrypted))
                 .isCompleted();
         record.value().rewind();
         assertEquals(1, encrypted.size());
         assertNotEquals(initial, encrypted);
 
         List<Record> decrypted = new ArrayList<>();
-        assertThat(doDecrypt(km, "foo", 1, encrypted, decrypted)).isCompleted();
+        assertThat(doDecrypt(decryptionManager, "foo", 1, encrypted, decrypted)).isCompleted();
 
         assertEquals(initial, decrypted);
     }
@@ -313,13 +318,13 @@ class InBandKeyManagerTest {
     @Test
     void decryptSupportsUnencryptedRecordValue() {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         byte[] recBytes = { 1, 2, 3 };
         Record record = RecordTestUtils.record(recBytes);
 
         List<Record> received = new ArrayList<>();
-        assertThat(doDecrypt(km, "foo", 1, List.of(record), received)).isCompleted();
+        assertThat(doDecrypt(decryptionManager, "foo", 1, List.of(record), received)).isCompleted();
 
         assertThat(received).hasSize(1);
         assertThat(received.stream()
@@ -335,8 +340,8 @@ class InBandKeyManagerTest {
     @MethodSource
     void decryptSupportsEmptyRecordBatches(MemoryRecords records) {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
-        assertThat(km.decrypt("foo", 1, records, ByteBufferOutputStream::new))
+        var decryptionManager = createDecryptionManager(kms);
+        assertThat(decryptionManager.decrypt("foo", 1, records, ByteBufferOutputStream::new))
                 .succeedsWithin(Duration.ZERO).isSameAs(records);
     }
 
@@ -344,7 +349,7 @@ class InBandKeyManagerTest {
     @Test
     void nullRecordValuesShouldNotBeModifiedAtEncryptTime() {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
 
         var kekId = kms.generateKey();
 
@@ -352,7 +357,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record);
-        assertThat(doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), initial, encrypted))
+        assertThat(doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), initial, encrypted))
                 .isCompleted();
         assertEquals(1, encrypted.size());
         assertFalse(encrypted.get(0).hasValue());
@@ -364,7 +369,7 @@ class InBandKeyManagerTest {
     @Test
     void nullRecordValuesAreIncompatibleWithHeaderEncryption() {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
 
         var kekId = kms.generateKey();
 
@@ -374,7 +379,7 @@ class InBandKeyManagerTest {
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record);
         String expectedMessage = "encrypting headers prohibited when original record value null, we must preserve the null for tombstoning";
-        assertThat(doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_HEADER_VALUES)), initial, encrypted))
+        assertThat(doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_HEADER_VALUES)), initial, encrypted))
                 .failsWithin(Duration.ofSeconds(5)).withThrowableThat()
                 .withMessageContaining(expectedMessage);
     }
@@ -382,13 +387,13 @@ class InBandKeyManagerTest {
     @Test
     void shouldTolerateEncryptingEmptyBatch() {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
 
         var kekId = kms.generateKey();
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of();
-        assertThat(doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), initial, encrypted))
+        assertThat(doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), initial, encrypted))
                 .isCompleted();
 
         assertEquals(0, encrypted.size());
@@ -397,10 +402,10 @@ class InBandKeyManagerTest {
     @Test
     void shouldTolerateEncryptingSingleBatchMemoryRecordsWithNoRecords() {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
         EncryptionScheme<UUID> scheme = createScheme(kms);
         MemoryRecords records = RecordTestUtils.memoryRecordsWithAllRecordsRemoved();
-        assertThat(encrypt(km, scheme, records)).succeedsWithin(Duration.ZERO).isSameAs(records);
+        assertThat(encrypt(encryptionManager, scheme, records)).succeedsWithin(Duration.ZERO).isSameAs(records);
     }
 
     @Test
@@ -408,7 +413,7 @@ class InBandKeyManagerTest {
         InMemoryKms kms = getInMemoryKms();
         var kekId = kms.generateKey();
         // configure 1 encryption per dek but then try to encrypt 2 records, will destroy and retry
-        var km = createKeyManager(kms, 1);
+        var encryptionManager = createEncryptionManager(kms, 1);
 
         var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
         var value2 = ByteBuffer.wrap(new byte[]{ 4, 5, 6 });
@@ -417,7 +422,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record, record2);
-        CompletionStage<Void> encrypt = doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        CompletionStage<Void> encrypt = doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted);
         assertThat(encrypt).failsWithin(Duration.ofSeconds(5)).withThrowableThat()
@@ -430,7 +435,7 @@ class InBandKeyManagerTest {
         var kekId = kms.generateKey();
         InMemoryKms spyKms = Mockito.spy(kms);
         when(spyKms.generateDekPair(kekId)).thenReturn(CompletableFuture.failedFuture(new EncryptorCreationException("failed to create that DEK")));
-        var km = createKeyManager(spyKms, 500000);
+        var encryptionManager = createEncryptionManager(spyKms, 500_000);
 
         var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
         var value2 = ByteBuffer.wrap(new byte[]{ 4, 5, 6 });
@@ -439,7 +444,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record, record2);
-        CompletionStage<Void> encrypt = doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        CompletionStage<Void> encrypt = doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted);
         assertThat(encrypt).failsWithin(Duration.ofSeconds(5)).withThrowableThat().withMessageContaining("failed to create that DEK");
@@ -452,7 +457,8 @@ class InBandKeyManagerTest {
         InMemoryKms spyKms = Mockito.spy(kms);
         doReturn(CompletableFuture.failedFuture(new KmsException("failed to create that DEK"))).when(spyKms).decryptEdek(any());
 
-        var km = createKeyManager(spyKms, 50000);
+        var encryptionManager = createEncryptionManager(spyKms, 500_000);
+        var decryptionManager = createDecryptionManager(spyKms);
 
         var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
         var value2 = ByteBuffer.wrap(new byte[]{ 4, 5, 6 });
@@ -461,13 +467,13 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record, record2);
-        CompletionStage<Void> encrypt = doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        CompletionStage<Void> encrypt = doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted);
         assertThat(encrypt).succeedsWithin(Duration.ofSeconds(5));
 
         List<Record> decrypted = new ArrayList<>();
-        CompletionStage<Void> decrypt = doDecrypt(km, "topic", 1, encrypted, decrypted);
+        CompletionStage<Void> decrypt = doDecrypt(decryptionManager, "topic", 1, encrypted, decrypted);
         assertThat(decrypt).failsWithin(Duration.ofSeconds(5)).withThrowableThat().withMessageContaining("failed to create that DEK");
     }
 
@@ -478,7 +484,7 @@ class InBandKeyManagerTest {
         InMemoryKms spyKms = Mockito.spy(kms);
         when(spyKms.generateDekPair(kekId)).thenReturn(CompletableFuture.failedFuture(new KmsException("failed to create that DEK")));
 
-        var km = createKeyManager(spyKms, 50000);
+        var encryptionManager = createEncryptionManager(spyKms, 50_000);
 
         var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
         var value2 = ByteBuffer.wrap(new byte[]{ 4, 5, 6 });
@@ -487,7 +493,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record, record2);
-        CompletionStage<Void> encrypt = doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        CompletionStage<Void> encrypt = doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted);
         assertThat(encrypt).failsWithin(Duration.ofSeconds(5)).withThrowableThat().withMessageContaining("failed to create that DEK");
@@ -496,7 +502,7 @@ class InBandKeyManagerTest {
         when(spyKms.generateDekPair(kekId)).thenCallRealMethod();
 
         // when
-        CompletionStage<Void> encrypt2 = doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        CompletionStage<Void> encrypt2 = doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted);
 
@@ -508,7 +514,8 @@ class InBandKeyManagerTest {
     @Test
     void shouldEncryptRecordValueForMultipleRecords() throws ExecutionException, InterruptedException, TimeoutException {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         var kekId = kms.generateKey();
 
@@ -520,7 +527,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record, record2);
-        doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted)
                 .toCompletableFuture()
@@ -532,7 +539,7 @@ class InBandKeyManagerTest {
         // TODO add assertion on headers
 
         List<Record> decrypted = new ArrayList<>();
-        doDecrypt(km, "foo", 1, encrypted, decrypted).toCompletableFuture()
+        doDecrypt(decryptionManager, "foo", 1, encrypted, decrypted).toCompletableFuture()
                 .get(10, TimeUnit.SECONDS);
 
         assertEquals(initial, decrypted);
@@ -541,7 +548,7 @@ class InBandKeyManagerTest {
     @Test
     void shouldGenerateNewDekIfOldDekHasNoRemainingEncryptions() throws ExecutionException, InterruptedException, TimeoutException {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 2);
+        var encryptionManager = createEncryptionManager(kms, 2);
 
         var kekId = kms.generateKey();
 
@@ -553,7 +560,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record, record2);
-        doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted).toCompletableFuture().get(10, TimeUnit.SECONDS);
         record.value().rewind();
@@ -561,7 +568,7 @@ class InBandKeyManagerTest {
 
         // at this point we have encrypted 2 records with the manager set to maximum 2 encryptions per dek
 
-        doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted).toCompletableFuture().get(10, TimeUnit.SECONDS);
 
@@ -579,7 +586,7 @@ class InBandKeyManagerTest {
     @Test
     void shouldGenerateNewDekIfOldOneHasSomeRemainingEncryptionsButNotEnoughForWholeBatch() throws ExecutionException, InterruptedException, TimeoutException {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 3);
+        var encryptionManager = createEncryptionManager(kms, 3);
 
         var kekId = kms.generateKey();
 
@@ -591,7 +598,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record, record2);
-        doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted)
                 .toCompletableFuture()
@@ -601,7 +608,7 @@ class InBandKeyManagerTest {
 
         // at this point we have encrypted 2 records with the manager set to maximum 3 encryptions per dek, so we need a new dek to encrypt 2 more records
 
-        doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted).toCompletableFuture().get(10, TimeUnit.SECONDS);
 
@@ -618,7 +625,7 @@ class InBandKeyManagerTest {
     @Test
     void shouldUseSameDekForMultipleBatches() throws ExecutionException, InterruptedException, TimeoutException {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 4);
+        var encryptionManager = createEncryptionManager(kms, 4);
 
         var kekId = kms.generateKey();
 
@@ -630,7 +637,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record, record2);
-        doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted)
                 .toCompletableFuture()
@@ -640,7 +647,7 @@ class InBandKeyManagerTest {
 
         // at this point we have encrypted 2 records with the manager set to maximum 4 encryptions per dek, so we do not need a new dek to encrypt 2 more records
 
-        doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 initial,
                 encrypted).toCompletableFuture().get(10, TimeUnit.SECONDS);
 
@@ -656,7 +663,8 @@ class InBandKeyManagerTest {
     @Test
     void shouldEncryptRecordHeaders() {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         var kekId = kms.generateKey();
 
@@ -666,7 +674,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record);
-        assertThat(doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE, RecordField.RECORD_HEADER_VALUES)),
+        assertThat(doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE, RecordField.RECORD_HEADER_VALUES)),
                 initial,
                 encrypted))
                 .isCompleted();
@@ -676,7 +684,7 @@ class InBandKeyManagerTest {
         assertNotEquals(initial, encrypted);
 
         List<Record> decrypted = new ArrayList<>();
-        assertThat(doDecrypt(km, "topicFoo", 1, encrypted, decrypted))
+        assertThat(doDecrypt(decryptionManager, "topicFoo", 1, encrypted, decrypted))
                 .isCompleted();
 
         assertEquals(List.of(RecordTestUtils.record(value, new RecordHeader("headerFoo", new byte[]{ 4, 5, 6 }))), decrypted);
@@ -685,7 +693,8 @@ class InBandKeyManagerTest {
     @Test
     void shouldEncryptRecordHeadersForMultipleRecords() throws ExecutionException, InterruptedException, TimeoutException {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         var kekId = kms.generateKey();
 
@@ -703,7 +712,7 @@ class InBandKeyManagerTest {
 
         List<Record> encrypted = new ArrayList<>();
         List<Record> initial = List.of(record, record2, record3);
-        doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE, RecordField.RECORD_HEADER_VALUES)),
+        doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE, RecordField.RECORD_HEADER_VALUES)),
                 initial,
                 encrypted).toCompletableFuture().get(10, TimeUnit.SECONDS);
         value.rewind();
@@ -713,7 +722,7 @@ class InBandKeyManagerTest {
         assertNotEquals(initial, encrypted);
 
         List<Record> decrypted = new ArrayList<>();
-        assertThat(doDecrypt(km, "foo", 1, encrypted, decrypted)).isCompleted();
+        assertThat(doDecrypt(decryptionManager, "foo", 1, encrypted, decrypted)).isCompleted();
 
         assertEquals(List.of(RecordTestUtils.record(0L, value, new RecordHeader("foo", new byte[]{ 4, 5, 6 })),
                 RecordTestUtils.record(1L, value2, new RecordHeader("foo", new byte[]{ 10, 11, 12 })),
@@ -723,7 +732,8 @@ class InBandKeyManagerTest {
     @Test
     void shouldPropagateHeadersInClearWhenNotEncryptingHeaders() {
         InMemoryKms kms = getInMemoryKms();
-        var km = createKeyManager(kms, 500_000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         var kekId = kms.generateKey();
 
@@ -732,7 +742,7 @@ class InBandKeyManagerTest {
         var record = RecordTestUtils.record(ByteBuffer.wrap(value), header);
 
         List<Record> encrypted = new ArrayList<>();
-        assertThat(doEncrypt(km, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), List.of(record), encrypted))
+        assertThat(doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), List.of(record), encrypted))
                 .isCompleted();
         assertThat(encrypted.iterator())
                 .toIterable()
@@ -743,7 +753,7 @@ class InBandKeyManagerTest {
                 .contains(header);
 
         List<Record> decrypted = new ArrayList<>();
-        assertThat(doDecrypt(km, "foo", 1, encrypted, decrypted))
+        assertThat(doDecrypt(decryptionManager, "foo", 1, encrypted, decrypted))
                 .isCompleted();
 
         assertThat(decrypted.iterator())
@@ -767,7 +777,8 @@ class InBandKeyManagerTest {
 
         var spyKms = Mockito.spy(kms);
 
-        var km = createKeyManager(spyKms, 50000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         byte[] rec1Bytes = { 1, 2, 3 };
         byte[] rec2Bytes = { 4, 5, 6 };
@@ -775,10 +786,10 @@ class InBandKeyManagerTest {
         var rec2 = RecordTestUtils.record(offsetB, ByteBuffer.wrap(rec2Bytes));
 
         List<Record> encrypted = new ArrayList<>();
-        var encryptStage = doEncrypt(km, topic, partition, new EncryptionScheme<>(kekId1, EnumSet.of(RecordField.RECORD_VALUE)),
+        var encryptStage = doEncrypt(encryptionManager, topic, partition, new EncryptionScheme<>(kekId1, EnumSet.of(RecordField.RECORD_VALUE)),
                 List.of(rec1),
                 encrypted)
-                .thenApply(u -> doEncrypt(km, topic, partition, new EncryptionScheme<>(kekId2, EnumSet.of(RecordField.RECORD_VALUE)),
+                .thenApply(u -> doEncrypt(encryptionManager, topic, partition, new EncryptionScheme<>(kekId2, EnumSet.of(RecordField.RECORD_VALUE)),
                         List.of(rec2),
                         encrypted));
         assertThat(encryptStage).isCompleted();
@@ -804,7 +815,7 @@ class InBandKeyManagerTest {
         }).when(spyKms).decryptEdek(argument.capture());
 
         List<Record> decrypted = new ArrayList<>();
-        var decryptStage = doDecrypt(km, topic, partition, encrypted, decrypted);
+        var decryptStage = doDecrypt(decryptionManager, topic, partition, encrypted, decrypted);
         assertThat(decryptStage).succeedsWithin(Duration.ofSeconds(1));
         assertThat(decrypted.iterator())
                 .toIterable()
@@ -824,7 +835,8 @@ class InBandKeyManagerTest {
         InMemoryKms kms = getInMemoryKms();
         var kekId = kms.generateKey();
 
-        var km = createKeyManager(kms, 50000);
+        var encryptionManager = createEncryptionManager(kms, 500_000);
+        var decryptionManager = createDecryptionManager(kms);
 
         byte[] rec1Bytes = { 1, 2, 3 };
         byte[] rec2Bytes = { 4, 5, 6 };
@@ -835,7 +847,7 @@ class InBandKeyManagerTest {
 
         // rec1 and rec3 will be encrypted.
         List<Record> encrypted = new ArrayList<>();
-        var encryptStage = doEncrypt(km, topic, partition, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+        var encryptStage = doEncrypt(encryptionManager, topic, partition, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
                 List.of(rec1, rec3),
                 encrypted);
         assertThat(encryptStage).isCompleted();
@@ -846,7 +858,7 @@ class InBandKeyManagerTest {
         decryptInput.add(1, rec2);
 
         List<Record> received = new ArrayList<>();
-        var decryptStage = doDecrypt(km, topic, partition, decryptInput, received);
+        var decryptStage = doDecrypt(decryptionManager, topic, partition, decryptInput, received);
         assertThat(decryptStage).succeedsWithin(Duration.ofSeconds(1));
         assertThat(received.iterator())
                 .toIterable()
@@ -875,8 +887,8 @@ class InBandKeyManagerTest {
 
     @NonNull
     private static List<TestingDek> extractEdeks(List<Record> encrypted) {
-        List<TestingDek> deks = encrypted.stream()
-                .filter(testingRecord -> Stream.of(testingRecord.headers()).anyMatch(header -> header.key().equals(InBandKeyManager.ENCRYPTION_HEADER_NAME)))
+        return encrypted.stream()
+                .filter(testingRecord -> Stream.of(testingRecord.headers()).anyMatch(header -> header.key().equals(InBandDecryptionManager.ENCRYPTION_HEADER_NAME)))
                 .map(testingRecord -> {
                     ByteBuffer wrapper = testingRecord.value();
                     var edekLength = ByteUtils.readUnsignedVarint(wrapper);
@@ -885,12 +897,16 @@ class InBandKeyManagerTest {
                     return new TestingDek(edekBytes);
                 })
                 .toList();
-        return deks;
     }
 
     @NonNull
-    private static InBandKeyManager<UUID, InMemoryEdek> createKeyManager(InMemoryKms kms, int maxEncryptionsPerDek) {
-        return new InBandKeyManager<>(kms, BufferPool.allocating(), maxEncryptionsPerDek);
+    private static InBandDecryptionManager<UUID, InMemoryEdek> createDecryptionManager(InMemoryKms kms) {
+        return new InBandDecryptionManager<>(kms);
+    }
+
+    @NonNull
+    private static InBandEncryptionManager<UUID, InMemoryEdek> createEncryptionManager(InMemoryKms kms, int maxEncryptionsPerDek) {
+        return new InBandEncryptionManager<>(kms, BufferPool.allocating(), maxEncryptionsPerDek, 5_000_000_000L);
     }
 
     @NonNull
@@ -900,7 +916,7 @@ class InBandKeyManagerTest {
     }
 
     @NonNull
-    private static CompletionStage<MemoryRecords> decrypt(InBandKeyManager<UUID, InMemoryEdek> km, MemoryRecords encrypted) {
+    private static CompletionStage<MemoryRecords> decrypt(InBandDecryptionManager<UUID, InMemoryEdek> km, MemoryRecords encrypted) {
         return km.decrypt("topic", 1, encrypted, ByteBufferOutputStream::new);
     }
 
@@ -911,7 +927,7 @@ class InBandKeyManagerTest {
     }
 
     @NonNull
-    private static CompletionStage<MemoryRecords> encrypt(InBandKeyManager<UUID, InMemoryEdek> km, EncryptionScheme<UUID> scheme, MemoryRecords records) {
+    private static CompletionStage<MemoryRecords> encrypt(InBandEncryptionManager<UUID, InMemoryEdek> km, EncryptionScheme<UUID> scheme, MemoryRecords records) {
         return km.encrypt("topic", 1, scheme, records, ByteBufferOutputStream::new);
     }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
@@ -15,10 +15,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 
-import io.kroxylicious.filter.encryption.dek.ExhaustedDekException;
-
 import org.junit.jupiter.api.Test;
 
+import io.kroxylicious.filter.encryption.dek.ExhaustedDekException;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryKms;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService;
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
@@ -15,6 +15,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 
+import io.kroxylicious.filter.encryption.dek.ExhaustedDekException;
+
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryKms;

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/RecordEncryptorTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/RecordEncryptorTest.java
@@ -86,7 +86,6 @@ class RecordEncryptorTest {
                 new EncryptionScheme<>("key", fields),
                 ENCRYPTOR,
                 EDEK_SERDE,
-                ByteBuffer.allocate(100),
                 ByteBuffer.allocate(100));
 
         Record record = RecordTestUtils.record(RecordBatch.MAGIC_VALUE_V2, offset, timestamp, key, value, headers);

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
@@ -72,7 +72,7 @@ class RecordBatchUtilsTest {
         MyRecordTransform mapper = new MyRecordTransform();
         var memoryRecords = RecordBatchUtils.toMemoryRecords(batch,
                 mapper,
-                new ByteBufferOutputStream(1000));
+                new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(1000))).build();
 
         // Then
         assertThat(mapper.initCalls).isEqualTo(996);


### PR DESCRIPTION
This is still a work in progress with a little more tidy up to do, but I thought I'd share how it's shaping up. I've made this a PR for my use-record-decryptor branch for now, so the logical progression from that is clearer. But once that one it merged I'll open this against the Kroxy repo.

A few key points

* I've split the KeyManager into two classes, an `EncryptionManager` for encryption and a `DecryptionManager` decryption.
* I've then gone on to refactor the `RecordEncryptor` to use the `DekManager`, replacing the use of `KeyContext` and `AesGcmEncryptor` on the encryption path with `Dek` and `Dek.Encryptor`
* I've reworked how buffer allocation works:
     - We make use of the fact the `Cipher` works with the same buffer for plain and ciphertext to mean we don't need two separate allocations (for the wrapperBuffer and parcelBuffer) any more.
    - Rather than figuring out how big a buffer we need for all the records in a batch (requiring an iteration), I'm allocating a fixed amount and reallocating should that be too small. This will eventually be a per-thread allocation (so re-used between invocations of the filter), but that's for a future PR.
    - This has necessitated reworking `Dek.Encryptor` slightly, splitting out a `preEncrypt()` from `encrypt()` (sorry about that).