### PR TITLE
Switch back to filter dispatch thread after KMS operations if required

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/FilterThreadExecutor.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/FilterThreadExecutor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Kroxylicious guarantees that there is a single thread associated with a Filter instance that is
+ * responsible for calling that Filter's methods. It may be useful for a Filter to be able to switch
+ * back to that thread to safely mutate filter member state.
+ */
+public class FilterThreadExecutor {
+    private final Executor executor;
+
+    public FilterThreadExecutor(@NonNull Executor executor) {
+        Objects.requireNonNull(executor);
+        this.executor = executor;
+    }
+
+    /**
+     * A Filter may need to ensure some CompletionStages are completed by the Filter thread
+     * so that they can safely mutate Filter state. This method will switch if the stage is not already
+     * completed, the assumption being the developer is calling this method from the Filter thread.
+     * If the stage is done then we return it as-is on the assumption further work chained from it will
+     * be executed directly, otherwise we switch to the Filter thread.
+     * @param stage stage
+     * @return if the stage is done it is returned unmodified, otherwise returns a stage that will be
+     * completed with the result of stage on the Filter thread
+     * @param <T> result type
+     */
+    public <T> @NonNull CompletionStage<T> completingOnFilterThread(@NonNull CompletionStage<T> stage) {
+        CompletableFuture<T> future = stage.toCompletableFuture();
+        if (future.isDone()) {
+            return stage;
+        }
+        else {
+            // no-op to switch executor
+            return future.whenCompleteAsync((t, throwable) -> {
+            }, executor);
+        }
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
@@ -127,7 +127,7 @@ class EnvelopeEncryptionFilterTest {
 
         when(decryptionManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.completedFuture(RecordTestUtils.singleElementMemoryRecords("decrypt", "decrypt")));
 
-        encryptionFilter = new EnvelopeEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector);
+        encryptionFilter = new EnvelopeEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, new FilterThreadExecutor(Runnable::run));
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.encryption;
 
 import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +35,7 @@ class EnvelopeEncryptionTest {
 
         doReturn(kmsService).when(fc).pluginInstance(KmsService.class, "KMS");
         doReturn(kms).when(kmsService).buildKms(any());
+        doReturn(mock(ScheduledExecutorService.class)).when(fc).eventLoop();
 
         doReturn(kekSelectorService).when(fc).pluginInstance(KekSelectorService.class, "SELECTOR");
         doReturn(kekSelector).when(kekSelectorService).buildSelector(any(), any());

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/FilterThreadExecutorTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/FilterThreadExecutorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilterThreadExecutorTest {
+
+    private final ExecutorService executorA = Executors.newSingleThreadExecutor(r -> new Thread(r, "a"));
+    private final ExecutorService executorB = Executors.newSingleThreadExecutor(r -> new Thread(r, "b"));
+    private final FilterThreadExecutor dispatchExecutor = new FilterThreadExecutor(executorB);
+
+    @Test
+    public void switchExecutorIfDeferred_SuccessSwitchesThreadIfDeferred() {
+        CompletableFuture<String> taskA = CompletableFuture.supplyAsync(() -> Thread.currentThread().getName(), executorA);
+        CompletionStage<String> switched = dispatchExecutor.completingOnFilterThread(taskA);
+        CompletionStage<Boolean> sameThread = switched.thenApply(thread -> thread.equals(Thread.currentThread().getName()));
+        assertThat(sameThread).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(false);
+    }
+
+    @Test
+    public void switchExecutorIfDeferred_SuccessDoesNotSwitchThreadIfDone() {
+        CompletableFuture<String> taskA = CompletableFuture.completedFuture(Thread.currentThread().getName());
+        CompletionStage<String> switched = dispatchExecutor.completingOnFilterThread(taskA);
+        CompletionStage<Boolean> sameThread = switched.thenApply(thread -> thread.equals(Thread.currentThread().getName()));
+        assertThat(sameThread).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(true);
+    }
+
+    @Test
+    public void switchExecutorIfDeferred_ExceptionSwitchesThreadIfDeferred() {
+        CompletableFuture<String> taskA = CompletableFuture.supplyAsync(() -> {
+            throw new TestException(Thread.currentThread().getName());
+        }, executorA);
+        CompletionStage<String> switched = dispatchExecutor.completingOnFilterThread(taskA);
+        CompletionStage<String> extractException = switched.exceptionally(throwable -> {
+            Assertions.assertThat(throwable).cause().isInstanceOf(TestException.class);
+            return ((TestException) throwable.getCause()).thread;
+        });
+        CompletionStage<Boolean> sameThread = extractException.thenApply(thread -> thread.equals(Thread.currentThread().getName()));
+        assertThat(sameThread).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(false);
+    }
+
+    @Test
+    public void switchExecutorIfDeferred_ExceptionDoesNotSwitchThreadIfDone() {
+        CompletableFuture<String> taskA = CompletableFuture.failedFuture(new TestException(Thread.currentThread().getName()));
+        CompletionStage<String> switched = dispatchExecutor.completingOnFilterThread(taskA);
+        CompletionStage<String> extractException = switched.exceptionally(throwable -> {
+            assertThat(throwable).isInstanceOf(TestException.class);
+            return ((TestException) throwable).thread;
+        });
+        CompletionStage<Boolean> sameThread = extractException.thenApply(thread -> thread.equals(Thread.currentThread().getName()));
+        assertThat(sameThread).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(true);
+    }
+
+    private static class TestException extends RuntimeException {
+        private final String thread;
+
+        TestException(String thread) {
+            super("test exception triggered from thread " + thread);
+            this.thread = thread;
+        }
+    }
+}


### PR DESCRIPTION
Why:
We are working with non-threadsafe structures and so want to be sure that access is limited to the eventloop of the filter instance.