### PR TITLE
Ingress refactor

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ProxyModelBuilder.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ProxyModelBuilder.java
@@ -46,7 +46,7 @@ public class ProxyModelBuilder {
         // to try and produce the most stable allocation of ports we can, we attempt to consider all clusters in the ingress allocation, even those
         // that we know are unacceptable due to unresolved dependencies.
         List<VirtualKafkaCluster> allClusters = resolutionResult.allClustersInNameOrder();
-        ProxyIngressModel ingressModel = IngressAllocator.allocateProxyIngressModel(primary, allClusters, ingresses, context);
+        ProxyIngressModel ingressModel = IngressAllocator.allocateProxyIngressModel(primary, context, resolutionResult);
         List<VirtualKafkaCluster> clustersWithValidIngresses = resolutionResult.fullyResolvedClustersInNameOrder().stream()
                 .filter(cluster -> ingressModel.clusterIngressModel(cluster).map(i -> i.ingressExceptions().isEmpty()).orElse(false)).toList();
         return new ProxyModel(resolutionResult, ingressModel, clustersWithValidIngresses);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
@@ -18,6 +18,7 @@ import java.util.stream.Stream;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
+import io.kroxylicious.kubernetes.api.common.LocalRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
@@ -29,6 +30,7 @@ import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.ClusterReso
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.UnresolvedDependency;
 
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByLocalRefMap;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByNameMap;
 import static io.kroxylicious.kubernetes.operator.resolver.Dependency.FILTER;
 import static io.kroxylicious.kubernetes.operator.resolver.Dependency.KAFKA_CLUSTER_REF;
@@ -52,7 +54,7 @@ public class DependencyResolverImpl implements DependencyResolver {
         if (virtualKafkaClusters.isEmpty()) {
             return EMPTY_RESOLUTION_RESULT;
         }
-        Map<String, KafkaProxyIngress> ingresses = context.getSecondaryResources(KafkaProxyIngress.class).stream().collect(toByNameMap());
+        Map<LocalRef<?>, KafkaProxyIngress> ingresses = context.getSecondaryResources(KafkaProxyIngress.class).stream().collect(toByLocalRefMap());
         Map<String, KafkaClusterRef> clusterRefs = context.getSecondaryResources(KafkaClusterRef.class).stream().collect(toByNameMap());
         Map<String, GenericKubernetesResource> filters = context.getSecondaryResources(GenericKubernetesResource.class).stream().collect(toByNameMap());
         var resolutionResult = virtualKafkaClusters.stream().map(cluster -> determineUnresolvedDependencies(cluster, ingresses, clusterRefs, filters))
@@ -63,7 +65,7 @@ public class DependencyResolverImpl implements DependencyResolver {
     }
 
     private ClusterResolutionResult determineUnresolvedDependencies(VirtualKafkaCluster cluster,
-                                                                    Map<String, KafkaProxyIngress> ingresses,
+                                                                    Map<LocalRef<?>, KafkaProxyIngress> ingresses,
                                                                     Map<String, KafkaClusterRef> clusterRefs,
                                                                     Map<String, GenericKubernetesResource> filters) {
         VirtualKafkaClusterSpec spec = cluster.getSpec();
@@ -96,9 +98,9 @@ public class DependencyResolverImpl implements DependencyResolver {
         }
     }
 
-    private static Stream<UnresolvedDependency> determineUnresolvedIngresses(VirtualKafkaClusterSpec spec, Map<String, KafkaProxyIngress> ingresses) {
+    private static Stream<UnresolvedDependency> determineUnresolvedIngresses(VirtualKafkaClusterSpec spec, Map<LocalRef<?>, KafkaProxyIngress> ingresses) {
         return spec.getIngressRefs().stream()
-                .filter(ref -> !ingresses.containsKey(ref.getName()))
+                .filter(ref -> !ingresses.containsKey(ref))
                 .map(ref -> new UnresolvedDependency(KAFKA_PROXY_INGRESS, ref.getName()));
     }
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
@@ -17,6 +17,7 @@ import java.util.function.Predicate;
 
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 
+import io.kroxylicious.kubernetes.api.common.LocalRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
@@ -32,7 +33,7 @@ import static java.util.Comparator.comparing;
  */
 public class ResolutionResult {
     private final Map<String, GenericKubernetesResource> filters;
-    private final Map<String, KafkaProxyIngress> kafkaProxyIngresses;
+    private final Map<LocalRef<?>, KafkaProxyIngress> kafkaProxyIngresses;
     private final Map<String, KafkaClusterRef> kafkaClusterRefs;
     private final Map<String, ClusterResolutionResult> clusterResolutionResults;
 
@@ -60,7 +61,7 @@ public class ResolutionResult {
     }
 
     ResolutionResult(Map<String, GenericKubernetesResource> filters,
-                     Map<String, KafkaProxyIngress> kafkaProxyIngresses,
+                     Map<LocalRef<?>, KafkaProxyIngress> kafkaProxyIngresses,
                      Map<String, KafkaClusterRef> kafkaClusterRefs,
                      Map<String, ClusterResolutionResult> clusterResolutionResults) {
         Objects.requireNonNull(filters);
@@ -108,6 +109,16 @@ public class ResolutionResult {
      */
     public Set<KafkaProxyIngress> ingresses() {
         return new HashSet<>(kafkaProxyIngresses.values());
+    }
+
+    /**
+     * Get KafkaProxyIngress for this reference
+     * @param localRef reference
+     * @return optional containing ingress if present, else empty
+     */
+    public Optional<KafkaProxyIngress> ingress(LocalRef<?> localRef) {
+        Objects.requireNonNull(localRef);
+        return Optional.ofNullable(kafkaProxyIngresses.get(localRef));
     }
 
     /**


### PR DESCRIPTION
Keying on LocalRef and making the resolution result responsible for the lookup tidies up the ingress allocator as we can pass the Ref from the CR around without having to convert to and from a name string.