### PR TITLE
Implement Fetch response error batching matching upstream

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/FetchAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/FetchAuthzIT.java
@@ -135,9 +135,9 @@ public class FetchAuthzIT extends AuthzIT {
         @Override
         public FetchRequestData requestData(String user, Map<String, Uuid> topicNameToId) {
             FetchRequestData fetchRequestData = new FetchRequestData();
-            FetchRequestData.FetchTopic topicA = createFetchTopic(ALICE_TO_READ_TOPIC_NAME, 0);
-            FetchRequestData.FetchTopic topicB = createFetchTopic(BOB_TO_READ_TOPIC_NAME, 0);
-            FetchRequestData.FetchTopic topicC = createFetchTopic(EXISTING_TOPIC_NAME, 0);
+            FetchRequestData.FetchTopic topicA = createFetchTopic(ALICE_TO_READ_TOPIC_NAME, 0, 20);
+            FetchRequestData.FetchTopic topicB = createFetchTopic(BOB_TO_READ_TOPIC_NAME, 0, 20);
+            FetchRequestData.FetchTopic topicC = createFetchTopic(EXISTING_TOPIC_NAME, 0, 20);
             fetchRequestData.setTopics(List.of(topicA, topicB, topicC));
             return fetchRequestData;
         }


### PR DESCRIPTION
I discovered that it's possible, when there are multiple topics in a fetch response, that it is possible for the PartitionData for a single topic to be spread over two FetchableTopicResponse. This is due to how the broker partitions the data into successful and erroneous topic partitions and then connects them back together in FetchResponse#toMessage.

Reproducer here that you can point at a fresh kafka cluster running on podman/docker https://gist.github.com/robobario/d71527aa4a12b2e15fdb0c4b06a07c4b