### PR TITLE
Refactors

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/AuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/AuthzIT.java
@@ -422,7 +422,7 @@ public class AuthzIT extends BaseIT {
                 producer.initTransactions();
                 producer.beginTransaction();
                 var sent = producer.send(new ProducerRecord<>(tmpName, "", "")).get();
-                System.err.println(sent.offset());
+                LOG.debug("producer record offset: {}", sent.offset());
                 producer.commitTransaction();
             }
             var consumerProps = new HashMap<>(aSuper);
@@ -451,7 +451,7 @@ public class AuthzIT extends BaseIT {
                 // consumer.seek(topicPartition, 0L);
                 var polled = consumer.poll(Duration.ofMillis(100));
 
-                System.err.println(polled.records(topicPartition));
+                LOG.debug("polled records: {}", polled.records(topicPartition));
                 consumer.commitSync();
             }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/AuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/AuthzIT.java
@@ -168,7 +168,9 @@ public class AuthzIT extends BaseIT {
 
         Q requestData(String user, BaseClusterFixture baseTestCluster);
 
-        ObjectNode convertResponse(S response);
+        default ObjectNode convertResponse(S response) {
+            return (ObjectNode) KafkaApiMessageConverter.responseConverterFor(apiKey().messageType).writer().apply(response, apiVersion());
+        }
 
         default Stream<Errors> errors(S response) {
             return convertResponse(response).findValues("errorCode").stream().map(node -> {
@@ -284,18 +286,6 @@ public class AuthzIT extends BaseIT {
         @Override
         public Map<String, String> passwords() {
             return Map.of(ALICE, "Alice");
-        }
-
-        @Override
-        public ObjectNode convertResponse(ApiMessage response) {
-            try {
-                var converter = Class.forName(response.getClass().getName() + "JsonConverter");
-                var method = converter.getDeclaredMethod("write", response.getClass(), Short.TYPE);
-                return (ObjectNode) method.invoke(null, response, apiVersion());
-            }
-            catch (ReflectiveOperationException e) {
-                throw new RuntimeException(e);
-            }
         }
 
         @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/CreatePartitionsAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/CreatePartitionsAuthzIT.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.message.CreatePartitionsRequestData;
 import org.apache.kafka.common.message.CreatePartitionsResponseData;
-import org.apache.kafka.common.message.CreatePartitionsResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
@@ -133,11 +132,6 @@ public class CreatePartitionsAuthzIT extends AuthzIT {
         @Override
         public CreatePartitionsRequestData requestData(String user, BaseClusterFixture clusterFixture) {
             return requestTemplate.request(user, clusterFixture);
-        }
-
-        @Override
-        public ObjectNode convertResponse(CreatePartitionsResponseData response) {
-            return (ObjectNode) CreatePartitionsResponseDataJsonConverter.write(response, apiVersion());
         }
 
         private Map<String, Integer> numPartitions(KafkaCluster cluster) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/CreateTopicsAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/CreateTopicsAuthzIT.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
-import org.apache.kafka.common.message.CreateTopicsResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.resource.PatternType;
@@ -127,11 +126,6 @@ public class CreateTopicsAuthzIT extends AuthzIT {
         @Override
         public CreateTopicsRequestData requestData(String user, BaseClusterFixture clusterFixture) {
             return requestTemplate.request(user, clusterFixture);
-        }
-
-        @Override
-        public ObjectNode convertResponse(CreateTopicsResponseData response) {
-            return (ObjectNode) CreateTopicsResponseDataJsonConverter.write(response, apiVersion());
         }
 
         @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/DeleteTopicsAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/DeleteTopicsAuthzIT.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;
 import org.apache.kafka.common.message.DeleteTopicsResponseData;
-import org.apache.kafka.common.message.DeleteTopicsResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
@@ -159,11 +158,6 @@ public class DeleteTopicsAuthzIT extends AuthzIT {
         @Override
         public DeleteTopicsRequestData requestData(String user, BaseClusterFixture clusterFixture) {
             return requestTemplate.request(user, clusterFixture);
-        }
-
-        @Override
-        public ObjectNode convertResponse(DeleteTopicsResponseData response) {
-            return (ObjectNode) DeleteTopicsResponseDataJsonConverter.write(response, apiVersion());
         }
 
         @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/FetchAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/FetchAuthzIT.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.FetchResponseData;
-import org.apache.kafka.common.message.FetchResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
@@ -139,11 +138,6 @@ public class FetchAuthzIT extends AuthzIT {
             FetchRequestData.FetchTopic topicC = createFetchTopic(EXISTING_TOPIC_NAME, 0);
             fetchRequestData.setTopics(List.of(topicA, topicB, topicC));
             return fetchRequestData;
-        }
-
-        @Override
-        public ObjectNode convertResponse(FetchResponseData response) {
-            return (ObjectNode) FetchResponseDataJsonConverter.write(response, apiVersion());
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/ListOffsetsAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/ListOffsetsAuthzIT.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.message.ListOffsetsResponseData;
-import org.apache.kafka.common.message.ListOffsetsResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
@@ -134,11 +133,6 @@ public class ListOffsetsAuthzIT extends AuthzIT {
             ListOffsetsRequestData.ListOffsetsTopic topicC = createListOffsetsTopic(EXISTING_TOPIC_NAME, 0, NON_EXISTANT_PARTITION);
             listOffsetsRequestData.setTopics(List.of(topicA, topicB, topicC));
             return listOffsetsRequestData;
-        }
-
-        @Override
-        public ObjectNode convertResponse(ListOffsetsResponseData response) {
-            return (ObjectNode) ListOffsetsResponseDataJsonConverter.write(response, apiVersion());
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/OffsetCommitAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/OffsetCommitAuthzIT.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.OffsetCommitResponseData;
-import org.apache.kafka.common.message.OffsetCommitResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
@@ -165,11 +164,6 @@ public class OffsetCommitAuthzIT extends AuthzIT {
         @Override
         public OffsetCommitRequestData requestData(String user, BaseClusterFixture clusterFixture) {
             return requestTemplate.request(user, clusterFixture);
-        }
-
-        @Override
-        public ObjectNode convertResponse(OffsetCommitResponseData response) {
-            return (ObjectNode) OffsetCommitResponseDataJsonConverter.write(response, apiVersion());
         }
 
         @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/OffsetFetchAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/OffsetFetchAuthzIT.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopic;
 import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopics;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
-import org.apache.kafka.common.message.OffsetFetchResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
@@ -201,11 +200,6 @@ public class OffsetFetchAuthzIT extends AuthzIT {
             fetchRequestData.setTopics(List.of(topicA, topicB, topicC));
             return fetchRequestData;
         }
-
-        @Override
-        public ObjectNode convertResponse(OffsetFetchResponseData response) {
-            return (ObjectNode) OffsetFetchResponseDataJsonConverter.write(response, apiVersion());
-        }
     }
 
     class OffsetFetchEquivalenceGroupBatching extends Equivalence<OffsetFetchRequestData, OffsetFetchResponseData> {
@@ -250,11 +244,6 @@ public class OffsetFetchAuthzIT extends AuthzIT {
             group.topics().addAll(List.of(topicA, topicB, topicC));
             fetchRequestData.setGroups(List.of(group));
             return fetchRequestData;
-        }
-
-        @Override
-        public ObjectNode convertResponse(OffsetFetchResponseData response) {
-            return (ObjectNode) OffsetFetchResponseDataJsonConverter.write(response, apiVersion());
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/OffsetForLeaderEpochAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/OffsetForLeaderEpochAuthzIT.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
-import org.apache.kafka.common.message.OffsetForLeaderEpochResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
@@ -146,11 +145,6 @@ public class OffsetForLeaderEpochAuthzIT extends AuthzIT {
             OffsetForLeaderTopic topicC = createOffsetForLeaderTopic(EXISTING_TOPIC_NAME, 0, 20);
             offsetForLeaderEpochRequestData.topics().addAll(List.of(topicA, topicB, topicC));
             return offsetForLeaderEpochRequestData;
-        }
-
-        @Override
-        public ObjectNode convertResponse(OffsetForLeaderEpochResponseData response) {
-            return (ObjectNode) OffsetForLeaderEpochResponseDataJsonConverter.write(response, apiVersion());
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/ProduceAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/ProduceAuthzIT.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
-import org.apache.kafka.common.message.ProduceResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.resource.PatternType;
@@ -135,11 +134,6 @@ public class ProduceAuthzIT extends AuthzIT {
         @Override
         public ProduceRequestData requestData(String user, BaseClusterFixture clusterFixture) {
             return requestTemplate.request(user, clusterFixture);
-        }
-
-        @Override
-        public ObjectNode convertResponse(ProduceResponseData response) {
-            return (ObjectNode) ProduceResponseDataJsonConverter.write(response, apiVersion());
         }
 
         @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/TxnOffsetCommitAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/TxnOffsetCommitAuthzIT.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
-import org.apache.kafka.common.message.TxnOffsetCommitResponseDataJsonConverter;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
@@ -203,7 +202,7 @@ public class TxnOffsetCommitAuthzIT extends AuthzIT {
 
         @Override
         public ApiKeys apiKey() {
-            return ApiKeys.OFFSET_FOR_LEADER_EPOCH;
+            return ApiKeys.TXN_OFFSET_COMMIT;
         }
 
         @Override
@@ -254,11 +253,6 @@ public class TxnOffsetCommitAuthzIT extends AuthzIT {
                         memberIdAndGeneration.memberId());
                 testStatesPerClusterUser.put(cluster.name() + ":" + username, state);
             });
-        }
-
-        @Override
-        public ObjectNode convertResponse(TxnOffsetCommitResponseData response) {
-            return (ObjectNode) TxnOffsetCommitResponseDataJsonConverter.write(response, apiVersion());
         }
     }
 


### PR DESCRIPTION
Close KafkaClients more harshly as the fail closed test was failing for me, running out of resources because the iouring resources were still tied up for 2 seconds after close is called. Also some `close` calls were missed.

Use generic message -> json converters.

Remove stderr writes to make checkstyle stop complaining