### PR TITLE
Workaround JDK17 compilation failure in docker image build

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java
@@ -89,12 +89,14 @@ public class DeleteTopicsEnforcement extends ApiEnforcement<DeleteTopicsRequestD
                         DeleteTopicsResponseData.DeletableTopicResultCollection v = new DeleteTopicsResponseData.DeletableTopicResultCollection();
                         okStates.stream()
                                 .map(topicState -> errorResult(apiVersion, topicState, Errors.TOPIC_AUTHORIZATION_FAILED))
-                                .forEach(v::mustAdd);
+                                // using method reference is failing to compile on JDK17, see JDK-8268312
+                                .forEach(newElement -> v.mustAdd(newElement));
                         errorStates.stream()
                                 .map(topicState -> {
                                     return getDeletableTopicResult(mapping, topicState, apiVersion);
                                 })
-                                .forEach(v::mustAdd);
+                                // using method reference is failing to compile on JDK17, see JDK-8268312
+                                .forEach(newElement -> v.mustAdd(newElement));
                         return context.requestFilterResultBuilder()
                                 .shortCircuitResponse(
                                         new DeleteTopicsResponseData()
@@ -136,7 +138,8 @@ public class DeleteTopicsEnforcement extends ApiEnforcement<DeleteTopicsRequestD
                         DeleteTopicsResponseData.DeletableTopicResultCollection v = new DeleteTopicsResponseData.DeletableTopicResultCollection();
                         request.topicNames().stream()
                                 .map(topicName -> errorResult(apiVersion, topicName, Errors.TOPIC_AUTHORIZATION_FAILED))
-                                .forEach(v::mustAdd);
+                                // using method reference is failing to compile on JDK17, see JDK-8268312
+                                .forEach(newElement -> v.mustAdd(newElement));
                         return context.requestFilterResultBuilder()
                                 .shortCircuitResponse(
                                         new DeleteTopicsResponseData()


### PR DESCRIPTION
The docker build is failing to compile with

```
[ERROR] /opt/kroxylicious/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/DeleteTopicsEnforcement.java:[97,42] incompatible types: invalid method reference
incompatible types: java.lang.Object cannot be converted to org.apache.kafka.common.message.DeleteTopicsResponseData.DeletableTopicResult
```

I think we're hitting a JDK bug https://bugs.openjdk.org/browse/JDK-8268312

Workaround is to use lambdas instead of method references, until we drop JDK17