### PR TITLE
Combine authorized operations on Metadata

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/pom.xml
+++ b/kroxylicious-filters/kroxylicious-authorization/pom.xml
@@ -59,6 +59,26 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
         </dependency>
@@ -70,6 +90,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-filter-test-support</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/FetchEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/FetchEnforcement.java
@@ -59,7 +59,7 @@ class FetchEnforcement extends ApiEnforcement<FetchRequestData, FetchResponseDat
                                 .shortCircuitResponse(response)
                                 .completed();
                     }
-                    else if (topicReadDecisions.get(Decision.DENY).isEmpty()) {
+                    else if (topicReadDecisions.getOrDefault(Decision.DENY, List.of()).isEmpty()) {
                         // Just forward if there's no denied topics
                         return context.forwardRequest(header, request);
                     }

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ListOffsetsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ListOffsetsEnforcement.java
@@ -54,7 +54,7 @@ class ListOffsetsEnforcement extends ApiEnforcement<ListOffsetsRequestData, List
                                 .shortCircuitResponse(response)
                                 .completed();
                     }
-                    else if (topicDescribeDecisions.get(Decision.DENY).isEmpty()) {
+                    else if (topicDescribeDecisions.getOrDefault(Decision.DENY, List.of()).isEmpty()) {
                         // Just forward if there's no denied topics
                         return context.forwardRequest(header, request);
                     }

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.authorization;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.RequestHeaderDataJsonConverter;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderDataJsonConverter;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.reflect.ClassPath;
+
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.authentication.User;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.test.requestresponsetestdef.KafkaApiMessageConverter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthorizationFilterTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+
+    private static final Pattern TEST_RESOURCE_FILTER = Pattern.compile("scenarios/.*\\.yaml");
+
+    static Stream<Arguments> authorization() throws Exception {
+        List<ClassPath.ResourceInfo> resources = ClassPath.from(AuthorizationFilterTest.class.getClassLoader()).getResources().stream()
+                .filter(ri -> TEST_RESOURCE_FILTER.matcher(ri.getResourceName()).matches()).toList();
+        return resources.stream().map(resourceInfo -> {
+            try {
+                ScenarioDefinition scenarioDefinition = MAPPER.reader().readValue(resourceInfo.asByteSource().read(), ScenarioDefinition.class);
+                return Arguments.argumentSet(resourceInfo.getResourceName(), scenarioDefinition);
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void authorization(ScenarioDefinition definition) {
+        SimpleAuthorizer authorizer = new SimpleAuthorizer(definition.given().authorizerRules());
+        AuthorizationFilter authorizationFilter = new AuthorizationFilter(authorizer);
+        ApiKeys apiKeys = definition.metadata().apiKeys();
+        short version = definition.metadata().apiVersion();
+        short requestHeaderVersion = apiKeys.requestHeaderVersion(version);
+        MockUpstream mockUpstream = new MockUpstream(definition.given().mockedUpstreamResponses());
+
+        ApiMessage request = KafkaApiMessageConverter.requestConverterFor(apiKeys.messageType).reader().apply(definition.when().request(), version);
+        RequestHeaderData requestHeader = RequestHeaderDataJsonConverter.read(definition.when().requestHeader(), requestHeaderVersion);
+
+        Map<Uuid, String> topicNames = Optional.ofNullable(definition.given().topicNames()).orElse(Map.of());
+        Subject subject = new Subject(new User(definition.when().subject()));
+        FilterContext context = new MockFilterContext(requestHeader, request, subject, topicNames, mockUpstream);
+        CompletionStage<RequestFilterResult> stage = authorizationFilter.onRequest(apiKeys, requestHeader, request, context);
+        RequestFilterResult actual = assertThat(stage).succeedsWithin(Duration.ZERO).actual();
+        if (actual.drop()) {
+            if (!mockUpstream.isFinished()) {
+                throw new IllegalStateException("mock upstream still has responses queued, but request was dropped by filter");
+            }
+        }
+        else {
+            if (!actual.shortCircuitResponse()) {
+                if (mockUpstream.isFinished()) {
+                    throw new IllegalStateException("mock upstream has no responses queued, but filter forwarded request");
+                }
+                ApiMessage forwardedMessage = Objects.requireNonNull(actual.message());
+                ApiMessage forwardedHeader = Objects.requireNonNull(actual.header());
+                MockUpstream.Response response = mockUpstream.respond((RequestHeaderData) forwardedHeader, forwardedMessage);
+                MockFilterContext responseContext = new MockFilterContext(response.header(), response.message(), subject, topicNames, mockUpstream);
+                CompletionStage<ResponseFilterResult> filterResultCompletionStage = authorizationFilter.onResponse(apiKeys, response.header(), response.message(),
+                        responseContext);
+                ResponseFilterResult responseResult = assertThat(filterResultCompletionStage).succeedsWithin(Duration.ZERO).actual();
+                if (responseResult.drop()) {
+                    assertThat(definition.then().expectedResponse()).isNull();
+                    assertThat(definition.then().expectedResponseHeader()).isNull();
+                }
+                else {
+                    String actualMessage = toYaml(KafkaApiMessageConverter.responseConverterFor(apiKeys.messageType).writer().apply(responseResult.message(), version));
+                    ApiMessage header = Objects.requireNonNull(responseResult.header());
+                    String actualHeader = toYaml(ResponseHeaderDataJsonConverter.write((ResponseHeaderData) header, apiKeys.responseHeaderVersion(version)));
+                    assertThat(actualMessage).isEqualTo(toYaml(definition.then().expectedResponse()));
+                    assertThat(actualHeader).isEqualTo(toYaml(definition.then().expectedResponseHeader()));
+                }
+            }
+            else {
+                if (!mockUpstream.isFinished()) {
+                    throw new IllegalStateException("mock upstream still has responses queued, but filter short circuit responded");
+                }
+                ApiMessage forwardedMessage = Objects.requireNonNull(actual.message());
+                ApiMessage forwardedHeader = Objects.requireNonNull(actual.header());
+                String actualMessage = toYaml(KafkaApiMessageConverter.responseConverterFor(apiKeys.messageType).writer().apply(forwardedMessage, version));
+                String actualHeader = toYaml(ResponseHeaderDataJsonConverter.write((ResponseHeaderData) forwardedHeader, apiKeys.responseHeaderVersion(version)));
+                assertThat(actualMessage).isEqualTo(toYaml(definition.then().expectedResponse()));
+                assertThat(actualHeader).isEqualTo(toYaml(definition.then().expectedResponseHeader()));
+            }
+        }
+    }
+
+    private static String toYaml(JsonNode actualBody) {
+        try {
+            return MAPPER.writer().writeValueAsString(actualBody);
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.authorization;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+
+import io.kroxylicious.proxy.authentication.ClientSaslContext;
+import io.kroxylicious.proxy.authentication.Subject;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResultBuilder;
+import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+import io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
+import io.kroxylicious.proxy.tls.ClientTlsContext;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public record MockFilterContext(ApiMessage header, ApiMessage message, Subject subject, Map<Uuid, String> topicNames, MockUpstream mockUpstream)
+        implements FilterContext {
+
+    public MockFilterContext {
+        Objects.requireNonNull(subject, "Subject cannot be null");
+    }
+
+    @NonNull
+    @Override
+    public String channelDescriptor() {
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public String sessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public ByteBufferOutputStream createByteBufferOutputStream(int initialCapacity) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Nullable
+    @Override
+    public String sniHostname() {
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public io.kroxylicious.proxy.filter.RequestFilterResultBuilder requestFilterResultBuilder() {
+        return new RequestFilterResultBuilder((RequestHeaderData) header, message);
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<RequestFilterResult> forwardRequest(@NonNull RequestHeaderData header, @NonNull ApiMessage request) {
+        return CompletableFuture.completedFuture(new MockRequestFilterResult(false, header, request, false, false));
+    }
+
+    @NonNull
+    @Override
+    public <M extends ApiMessage> CompletionStage<M> sendRequest(@NonNull RequestHeaderData header, @NonNull ApiMessage request) {
+        return mockUpstream.sendRequest(header, request);
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<TopicNameMapping> topicNames(Collection<Uuid> topicIds) {
+        Map<Boolean, List<Uuid>> hasName = topicIds.stream().collect(Collectors.partitioningBy(topicNames::containsKey));
+        List<Uuid> haveNames = hasName.get(true);
+        List<Uuid> noNames = hasName.get(false);
+        Map<Uuid, String> haveNamesMap = haveNames.stream().collect(Collectors.toMap(topic -> topic, topicNames::get));
+        Map<Uuid, TopicNameMappingException> noNamesMap = noNames.stream()
+                .collect(Collectors.toMap(topic -> topic, topic -> new TopicNameMappingException(Errors.UNKNOWN_SERVER_ERROR)));
+        return CompletableFuture.completedFuture(new TopicNameMapping() {
+            @Override
+            public boolean anyFailures() {
+                return !noNames.isEmpty();
+            }
+
+            @Override
+            public Map<Uuid, String> topicNames() {
+                return haveNamesMap;
+            }
+
+            @Override
+            public Map<Uuid, TopicNameMappingException> failures() {
+                return noNamesMap;
+            }
+        });
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<ResponseFilterResult> forwardResponse(@NonNull ResponseHeaderData header, @NonNull ApiMessage response) {
+        return CompletableFuture.completedFuture(new MockResponseFilterResult(header, response, false, false));
+    }
+
+    @NonNull
+    @Override
+    public ResponseFilterResultBuilder responseFilterResultBuilder() {
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public String getVirtualClusterName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public Optional<ClientTlsContext> clientTlsContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clientSaslAuthenticationSuccess(@NonNull String mechanism, @NonNull String authorizedId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clientSaslAuthenticationSuccess(@NonNull String mechanism, @NonNull Subject subject) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clientSaslAuthenticationFailure(@Nullable String mechanism, @Nullable String authorizedId, @NonNull Exception exception) {
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public Optional<ClientSaslContext> clientSaslContext() {
+        throw new UnsupportedOperationException();
+    }
+
+    @NonNull
+    @Override
+    public Subject authenticatedSubject() {
+        return subject;
+    }
+
+    record MockRequestFilterResult(boolean shortCircuitResponse,
+                                   @Nullable ApiMessage header,
+                                   @Nullable ApiMessage message,
+                                   boolean closeConnection,
+                                   boolean drop)
+            implements RequestFilterResult {}
+
+    record MockResponseFilterResult(@Nullable ApiMessage header,
+                                    @Nullable ApiMessage message,
+                                    boolean closeConnection,
+                                    boolean drop)
+            implements ResponseFilterResult {}
+
+    record RequestTerminalStage(MockRequestFilterResult result) implements TerminalStage<RequestFilterResult> {
+
+        @NonNull
+        @Override
+        public RequestFilterResult build() {
+            return result;
+        }
+
+        @NonNull
+        @Override
+        public CompletionStage<RequestFilterResult> completed() {
+            return CompletableFuture.completedFuture(result);
+        }
+    }
+
+    record RequestCloseOrTerminalStage(MockRequestFilterResult result) implements CloseOrTerminalStage<RequestFilterResult> {
+
+        @NonNull
+        @Override
+        public TerminalStage<RequestFilterResult> withCloseConnection() {
+            return new RequestTerminalStage(new MockRequestFilterResult(result.shortCircuitResponse, result().header, result().message, true, result.drop()));
+        }
+
+        @NonNull
+        @Override
+        public RequestFilterResult build() {
+            return result;
+        }
+
+        @NonNull
+        @Override
+        public CompletionStage<RequestFilterResult> completed() {
+            return CompletableFuture.completedFuture(result);
+        }
+    }
+
+    record RequestFilterResultBuilder(RequestHeaderData header, ApiMessage message) implements io.kroxylicious.proxy.filter.RequestFilterResultBuilder {
+
+        @NonNull
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(@Nullable ResponseHeaderData header, @NonNull ApiMessage message)
+                throws IllegalArgumentException {
+            return new RequestCloseOrTerminalStage(new MockRequestFilterResult(true, header, message, false, false));
+        }
+
+        @NonNull
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(@NonNull ApiMessage message) throws IllegalArgumentException {
+            ResponseHeaderData respo = new ResponseHeaderData();
+            respo.setCorrelationId(header.correlationId());
+            return new RequestCloseOrTerminalStage(new MockRequestFilterResult(true, respo, message, false, false));
+        }
+
+        @NonNull
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> errorResponse(@NonNull RequestHeaderData header, @NonNull ApiMessage message, @NonNull ApiException apiException)
+                throws IllegalArgumentException {
+            throw new IllegalArgumentException();
+        }
+
+        @NonNull
+        @Override
+        public CloseOrTerminalStage<RequestFilterResult> forward(@NonNull RequestHeaderData header, @NonNull ApiMessage message) throws IllegalArgumentException {
+            return new RequestCloseOrTerminalStage(new MockRequestFilterResult(false, header, message, false, false));
+        }
+
+        @NonNull
+        @Override
+        public TerminalStage<RequestFilterResult> drop() {
+            return new RequestTerminalStage(new MockRequestFilterResult(false, null, null, false, true));
+        }
+
+        @NonNull
+        @Override
+        public TerminalStage<RequestFilterResult> withCloseConnection() {
+            return new RequestTerminalStage(new MockRequestFilterResult(false, null, null, true, false));
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockUpstream.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockUpstream.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.authorization;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.RequestHeaderDataJsonConverter;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderDataJsonConverter;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.kroxylicious.test.requestresponsetestdef.KafkaApiMessageConverter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MockUpstream {
+    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+    private final List<ScenarioDefinition.MockResponse> mockResponses;
+
+    public MockUpstream(List<ScenarioDefinition.MockResponse> mockResponses) {
+        this.mockResponses = mockResponses;
+    }
+
+    public <M extends ApiMessage> CompletionStage<M> sendRequest(RequestHeaderData header, ApiMessage request) {
+        if (mockResponses.isEmpty()) {
+            throw new IllegalStateException("No mock responses remaining!");
+        }
+        try {
+            Response response = respond(header, request);
+            return CompletableFuture.completedFuture((M) response.message());
+        }
+        catch (Exception e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private ScenarioDefinition.MockResponse pop() {
+        return this.mockResponses.remove(0);
+    }
+
+    private static String toYaml(JsonNode actualBody) {
+        try {
+            return MAPPER.writer().writeValueAsString(actualBody);
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean isFinished() {
+        return mockResponses.isEmpty();
+    }
+
+    public Response respond(RequestHeaderData requestHeader, ApiMessage request) {
+        ScenarioDefinition.MockResponse mockDefinition = pop();
+        ApiKeys key = mockDefinition.expectedRequestKey();
+        assertThat(key).isEqualTo(ApiKeys.forId(requestHeader.requestApiKey()));
+        short version = mockDefinition.expectedRequestVersion();
+        assertThat(requestHeader.requestApiVersion()).isEqualTo(version);
+        JsonNode actualHeader = RequestHeaderDataJsonConverter.write(requestHeader, key.requestHeaderVersion(version));
+        assertThat(toYaml(actualHeader)).isEqualTo(toYaml(mockDefinition.expectedRequestHeader()));
+        JsonNode actualBody = KafkaApiMessageConverter.requestConverterFor(key.messageType).writer().apply(request, version);
+        assertThat(toYaml(actualBody)).isEqualTo(toYaml(mockDefinition.expectedRequest()));
+        JsonNode jsonNode = mockDefinition.upstreamResponse();
+        ResponseHeaderData header = ResponseHeaderDataJsonConverter.read(mockDefinition.upstreamResponseHeader(), key.requestHeaderVersion(version));
+        ApiMessage responseMessage = KafkaApiMessageConverter.responseConverterFor(key.messageType).reader().apply(jsonNode, version);
+        return new Response(header, responseMessage);
+    }
+
+    public record Response(ResponseHeaderData header, ApiMessage message) {}
+}

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ScenarioDefinition.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ScenarioDefinition.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.authorization;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public record ScenarioDefinition(Metadata metadata, Given given, When when, Then then) {
+    public record Metadata(ApiKeys apiKeys, short apiVersion, String scenario) {
+
+    }
+
+    public record MockResponse(ApiKeys expectedRequestKey, short expectedRequestVersion, JsonNode expectedRequestHeader, JsonNode expectedRequest,
+                               JsonNode upstreamResponseHeader, JsonNode upstreamResponse) {
+
+    }
+
+    /**
+     * @param mockedUpstreamResponses response for mock upstream to respond with, empty if expect no requests to be sent upstream
+     * @param authorizerRules rules
+     * @param topicNames topic id to topic name map
+     */
+    public record Given(List<MockResponse> mockedUpstreamResponses, SimpleAuthorizer.Config authorizerRules,
+                        @Nullable Map<Uuid, String> topicNames) {}
+
+    /**
+     * @param subject subject sending the request
+     * @param requestHeader header to send
+     * @param request request to send
+     */
+    public record When(String subject, JsonNode requestHeader, JsonNode request) {}
+
+    /**
+     * @param expectedResponseHeader
+     * @param expectedResponse
+     */
+    public record Then(@Nullable JsonNode expectedResponseHeader, @Nullable JsonNode expectedResponse) {}
+}

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/SimpleAuthorizer.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/SimpleAuthorizer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.authorization;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.kroxylicious.authorizer.service.Action;
+import io.kroxylicious.authorizer.service.AuthorizeResult;
+import io.kroxylicious.authorizer.service.Authorizer;
+import io.kroxylicious.authorizer.service.ResourceType;
+import io.kroxylicious.proxy.authentication.Principal;
+import io.kroxylicious.proxy.authentication.Subject;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class SimpleAuthorizer implements Authorizer {
+
+    private final Set<AllowedOperation> allowedOperations;
+
+    SimpleAuthorizer(Config config) {
+        this.allowedOperations = config.allowed().stream().map(allowedActionDef -> {
+            ResourceType<?> resourceType = allowedActionDef.resourceClass().toResourceType(allowedActionDef.resourceType);
+            return new AllowedOperation(allowedActionDef.subject, allowedActionDef.resourceName, resourceType);
+        }).collect(Collectors.toSet());
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<AuthorizeResult> authorize(Subject subject, @NonNull List<io.kroxylicious.authorizer.service.Action> actions) {
+        Set<Principal> principals = subject.principals();
+        if (principals.size() != 1) {
+            throw new IllegalStateException("Subject must have exactly one principal");
+        }
+        String principal = principals.stream().findFirst().map(Principal::name).orElseThrow();
+        Map<Boolean, List<Action>> collect = actions.stream().collect(Collectors.partitioningBy(action -> {
+            AllowedOperation operation = new AllowedOperation(principal, action.resourceName(), action.operation());
+            return allowedOperations.contains(operation);
+        }));
+        return CompletableFuture.completedFuture(new AuthorizeResult(subject, collect.get(true), collect.get(false)));
+    }
+
+    @NonNull
+    @Override
+    public Optional<Set<Class<? extends ResourceType<?>>>> supportedResourceTypes() {
+        return Optional.of(Set.of(TopicResource.class, ClusterResource.class));
+    }
+
+    record Config(List<AllowedActionDef> allowed) {
+
+    }
+
+    enum TargetResourceType {
+        TOPIC(TopicResource::valueOf),
+        CLUSTER(ClusterResource::valueOf);
+
+        private final Function<String, ResourceType<?>> resourceTypeFunction;
+
+        TargetResourceType(Function<String, ResourceType<?>> resourceTypeFunction) {
+            this.resourceTypeFunction = resourceTypeFunction;
+        }
+
+        public ResourceType<?> toResourceType(String resourceName) {
+            return resourceTypeFunction.apply(resourceName);
+        }
+    }
+
+    record AllowedOperation(String subject, String resourceName, ResourceType<?> operation) {
+
+    }
+
+    record AllowedActionDef(String subject, String resourceName, TargetResourceType resourceClass, String resourceType) {
+
+    }
+}

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/0/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_OFFSETS_TO_TXN"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_OFFSETS_TO_TXN"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 25
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-502"
+        producerId: 190
+        producerEpoch: 312
+        groupId: "random-string-96"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 312
+        errorCode: 96
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 25
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-502"
+    producerId: 190
+    producerEpoch: 312
+    groupId: "random-string-96"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 312
+    errorCode: 96

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/1/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_OFFSETS_TO_TXN"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_OFFSETS_TO_TXN"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 25
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-877"
+        producerId: 574
+        producerEpoch: 183
+        groupId: "random-string-58"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 190
+        errorCode: 890
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 25
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-877"
+    producerId: 574
+    producerEpoch: 183
+    groupId: "random-string-58"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 190
+    errorCode: 890

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/2/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_OFFSETS_TO_TXN"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_OFFSETS_TO_TXN"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 25
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-815"
+        producerId: 333
+        producerEpoch: 75
+        groupId: "random-string-299"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 58
+        errorCode: 502
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 25
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-815"
+    producerId: 333
+    producerEpoch: 75
+    groupId: "random-string-299"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 58
+    errorCode: 502

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/3/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_OFFSETS_TO_TXN"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_OFFSETS_TO_TXN"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 25
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-241"
+        producerId: 242
+        producerEpoch: 776
+        groupId: "random-string-856"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 259
+        errorCode: 183
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 25
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-241"
+    producerId: 242
+    producerEpoch: 776
+    groupId: "random-string-856"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 259
+    errorCode: 183

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_OFFSETS_TO_TXN/4/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_OFFSETS_TO_TXN"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_OFFSETS_TO_TXN"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 25
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-920"
+        producerId: 246
+        producerEpoch: 624
+        groupId: "random-string-527"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 877
+        errorCode: 574
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 25
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-920"
+    producerId: 246
+    producerEpoch: 624
+    groupId: "random-string-527"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 877
+    errorCode: 574

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/0/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_PARTITIONS_TO_TXN"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_PARTITIONS_TO_TXN"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 24
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        v3AndBelowTransactionalId: "random-string-67"
+        v3AndBelowProducerId: 180
+        v3AndBelowProducerEpoch: 312
+        v3AndBelowTopics:
+          - name: "random-string-776"
+            partitions:
+              - 863
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 333
+        resultsByTopicV3AndBelow:
+          - name: "random-string-299"
+            resultsByPartition:
+              - partitionIndex: 547
+                partitionErrorCode: 75
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 24
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    v3AndBelowTransactionalId: "random-string-67"
+    v3AndBelowProducerId: 180
+    v3AndBelowProducerEpoch: 312
+    v3AndBelowTopics:
+      - name: "random-string-776"
+        partitions:
+          - 863
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 333
+    resultsByTopicV3AndBelow:
+      - name: "random-string-299"
+        resultsByPartition:
+          - partitionIndex: 547
+            partitionErrorCode: 75

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/1/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_PARTITIONS_TO_TXN"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_PARTITIONS_TO_TXN"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 24
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        v3AndBelowTransactionalId: "random-string-155"
+        v3AndBelowProducerId: 743
+        v3AndBelowProducerEpoch: 122
+        v3AndBelowTopics:
+          - name: "random-string-932"
+            partitions:
+              - 620
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 263
+        resultsByTopicV3AndBelow:
+          - name: "random-string-815"
+            resultsByPartition:
+              - partitionIndex: 776
+                partitionErrorCode: 856
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 24
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    v3AndBelowTransactionalId: "random-string-155"
+    v3AndBelowProducerId: 743
+    v3AndBelowProducerEpoch: 122
+    v3AndBelowTopics:
+      - name: "random-string-932"
+        partitions:
+          - 620
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 263
+    resultsByTopicV3AndBelow:
+      - name: "random-string-815"
+        resultsByPartition:
+          - partitionIndex: 776
+            partitionErrorCode: 856

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/2/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_PARTITIONS_TO_TXN"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_PARTITIONS_TO_TXN"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 24
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        v3AndBelowTransactionalId: "random-string-662"
+        v3AndBelowProducerId: 662
+        v3AndBelowProducerEpoch: 714
+        v3AndBelowTopics:
+          - name: "random-string-513"
+            partitions:
+              - 814
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 624
+        resultsByTopicV3AndBelow:
+          - name: "random-string-242"
+            resultsByPartition:
+              - partitionIndex: 527
+                partitionErrorCode: 241
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 24
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    v3AndBelowTransactionalId: "random-string-662"
+    v3AndBelowProducerId: 662
+    v3AndBelowProducerEpoch: 714
+    v3AndBelowTopics:
+      - name: "random-string-513"
+        partitions:
+          - 814
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 624
+    resultsByTopicV3AndBelow:
+      - name: "random-string-242"
+        resultsByPartition:
+          - partitionIndex: 527
+            partitionErrorCode: 241

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/3/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_PARTITIONS_TO_TXN"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_PARTITIONS_TO_TXN"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 24
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        v3AndBelowTransactionalId: "random-string-416"
+        v3AndBelowProducerId: 214
+        v3AndBelowProducerEpoch: 68
+        v3AndBelowTopics:
+          - name: "random-string-660"
+            partitions:
+              - 144
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 312
+        resultsByTopicV3AndBelow:
+          - name: "random-string-856"
+            resultsByPartition:
+              - partitionIndex: 920
+                partitionErrorCode: 246
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 24
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    v3AndBelowTransactionalId: "random-string-416"
+    v3AndBelowProducerId: 214
+    v3AndBelowProducerEpoch: 68
+    v3AndBelowTopics:
+      - name: "random-string-660"
+        partitions:
+          - 144
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 312
+    resultsByTopicV3AndBelow:
+      - name: "random-string-856"
+        resultsByPartition:
+          - partitionIndex: 920
+            partitionErrorCode: 246

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/4/baseline.yaml
@@ -1,0 +1,79 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_PARTITIONS_TO_TXN"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_PARTITIONS_TO_TXN"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 24
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactions:
+          - transactionalId: "random-string-398"
+            producerId: 571
+            producerEpoch: 988
+            verifyOnly: true
+            topics:
+              - name: "random-string-545"
+                partitions:
+                  - 413
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 122
+        errorCode: 799
+        resultsByTransaction:
+          - transactionalId: "random-string-67"
+            topicResults:
+              - name: "random-string-180"
+                resultsByPartition:
+                  - partitionIndex: 863
+                    partitionErrorCode: 776
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 24
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactions:
+      - transactionalId: "random-string-398"
+        producerId: 571
+        producerEpoch: 988
+        verifyOnly: true
+        topics:
+          - name: "random-string-545"
+            partitions:
+              - 413
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 122
+    errorCode: 799
+    resultsByTransaction:
+      - transactionalId: "random-string-67"
+        topicResults:
+          - name: "random-string-180"
+            resultsByPartition:
+              - partitionIndex: 863
+                partitionErrorCode: 776

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ADD_PARTITIONS_TO_TXN/5/baseline.yaml
@@ -1,0 +1,79 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "ADD_PARTITIONS_TO_TXN"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "ADD_PARTITIONS_TO_TXN"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 24
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactions:
+          - transactionalId: "random-string-937"
+            producerId: 975
+            producerEpoch: 401
+            verifyOnly: true
+            topics:
+              - name: "random-string-166"
+                partitions:
+                  - 263
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 714
+        errorCode: 715
+        resultsByTransaction:
+          - transactionalId: "random-string-155"
+            topicResults:
+              - name: "random-string-743"
+                resultsByPartition:
+                  - partitionIndex: 620
+                    partitionErrorCode: 932
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 24
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactions:
+      - transactionalId: "random-string-937"
+        producerId: 975
+        producerEpoch: 401
+        verifyOnly: true
+        topics:
+          - name: "random-string-166"
+            partitions:
+              - 263
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 714
+    errorCode: 715
+    resultsByTransaction:
+      - transactionalId: "random-string-155"
+        topicResults:
+          - name: "random-string-743"
+            resultsByPartition:
+              - partitionIndex: 620
+                partitionErrorCode: 932

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/0/baseline.yaml
@@ -1,0 +1,53 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "API_VERSIONS"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "API_VERSIONS"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 18
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest: { }
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 700
+        apiKeys:
+          - apiKey: 3
+            minVersion: 0
+            maxVersion: 13
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 18
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request: { }
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 700
+    apiKeys:
+      - apiKey: 3
+        minVersion: 0
+        maxVersion: 13

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/1/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "API_VERSIONS"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "API_VERSIONS"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 18
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest: { }
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 414
+        apiKeys:
+          - apiKey: 3
+            minVersion: 0
+            maxVersion: 13
+        throttleTimeMs: 478
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 18
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request: { }
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 414
+    apiKeys:
+      - apiKey: 3
+        minVersion: 0
+        maxVersion: 13
+    throttleTimeMs: 478

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/2/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "API_VERSIONS"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "API_VERSIONS"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 18
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest: { }
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 607
+        apiKeys:
+          - apiKey: 3
+            minVersion: 0
+            maxVersion: 13
+        throttleTimeMs: 855
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 18
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request: { }
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 607
+    apiKeys:
+      - apiKey: 3
+        minVersion: 0
+        maxVersion: 13
+    throttleTimeMs: 855

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/3/baseline.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "API_VERSIONS"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "API_VERSIONS"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 18
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        clientSoftwareName: "random-string-439"
+        clientSoftwareVersion: "random-string-267"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 35
+        apiKeys:
+          - apiKey: 3
+            minVersion: 0
+            maxVersion: 13
+        throttleTimeMs: 315
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 18
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    clientSoftwareName: "random-string-439"
+    clientSoftwareVersion: "random-string-267"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 35
+    apiKeys:
+      - apiKey: 3
+        minVersion: 0
+        maxVersion: 13
+    throttleTimeMs: 315

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/4/baseline.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "API_VERSIONS"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "API_VERSIONS"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 18
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        clientSoftwareName: "random-string-313"
+        clientSoftwareVersion: "random-string-234"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 45
+        apiKeys:
+          - apiKey: 3
+            minVersion: 0
+            maxVersion: 13
+        throttleTimeMs: 880
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 18
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    clientSoftwareName: "random-string-313"
+    clientSoftwareVersion: "random-string-234"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 45
+    apiKeys:
+      - apiKey: 3
+        minVersion: 0
+        maxVersion: 13
+    throttleTimeMs: 880

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/0/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_PARTITIONS"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_PARTITIONS"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 37
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            count: 753
+            assignments:
+              - brokerIds:
+                  - 237
+        timeoutMs: 844
+        validateOnly: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 580
+        results:
+          - name: "my-topic"
+            errorCode: 52
+            errorMessage: "random-string-860"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "ALTER"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 37
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        count: 753
+        assignments:
+          - brokerIds:
+              - 237
+    timeoutMs: 844
+    validateOnly: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 580
+    results:
+      - name: "my-topic"
+        errorCode: 52
+        errorMessage: "random-string-860"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/1/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_PARTITIONS"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_PARTITIONS"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 37
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            count: 291
+            assignments:
+              - brokerIds:
+                  - 609
+        timeoutMs: 400
+        validateOnly: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 983
+        results:
+          - name: "my-topic"
+            errorCode: 873
+            errorMessage: "random-string-965"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "ALTER"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 37
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        count: 291
+        assignments:
+          - brokerIds:
+              - 609
+    timeoutMs: 400
+    validateOnly: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 983
+    results:
+      - name: "my-topic"
+        errorCode: 873
+        errorMessage: "random-string-965"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/2/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_PARTITIONS"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_PARTITIONS"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 37
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            count: 596
+            assignments:
+              - brokerIds:
+                  - 748
+        timeoutMs: 1021
+        validateOnly: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 173
+        results:
+          - name: "my-topic"
+            errorCode: 685
+            errorMessage: "random-string-491"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "ALTER"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 37
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        count: 596
+        assignments:
+          - brokerIds:
+              - 748
+    timeoutMs: 1021
+    validateOnly: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 173
+    results:
+      - name: "my-topic"
+        errorCode: 685
+        errorMessage: "random-string-491"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/3/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_PARTITIONS"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_PARTITIONS"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 37
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            count: 650
+            assignments:
+              - brokerIds:
+                  - 964
+        timeoutMs: 69
+        validateOnly: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 552
+        results:
+          - name: "my-topic"
+            errorCode: 19
+            errorMessage: "random-string-778"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "ALTER"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 37
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        count: 650
+        assignments:
+          - brokerIds:
+              - 964
+    timeoutMs: 69
+    validateOnly: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 552
+    results:
+      - name: "my-topic"
+        errorCode: 19
+        errorMessage: "random-string-778"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/2/baseline.yaml
@@ -1,0 +1,79 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_TOPICS"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_TOPICS"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 19
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            numPartitions: 746
+            replicationFactor: 874
+            assignments:
+              - partitionIndex: 937
+                brokerIds:
+                  - 728
+            configs:
+              - name: "random-string-170"
+                value: "random-string-292"
+        timeoutMs: 167
+        validateOnly: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 295
+        topics:
+          - name: "random-string-569"
+            errorCode: 52
+            errorMessage: "random-string-921"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 19
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        numPartitions: 746
+        replicationFactor: 874
+        assignments:
+          - partitionIndex: 937
+            brokerIds:
+              - 728
+        configs:
+          - name: "random-string-170"
+            value: "random-string-292"
+    timeoutMs: 167
+    validateOnly: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 295
+    topics:
+      - name: "random-string-569"
+        errorCode: 52
+        errorMessage: "random-string-921"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/3/baseline.yaml
@@ -1,0 +1,79 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_TOPICS"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_TOPICS"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 19
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            numPartitions: 998
+            replicationFactor: 625
+            assignments:
+              - partitionIndex: 1002
+                brokerIds:
+                  - 90
+            configs:
+              - name: "random-string-377"
+                value: "random-string-192"
+        timeoutMs: 330
+        validateOnly: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 395
+        topics:
+          - name: "random-string-517"
+            errorCode: 852
+            errorMessage: "random-string-875"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 19
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        numPartitions: 998
+        replicationFactor: 625
+        assignments:
+          - partitionIndex: 1002
+            brokerIds:
+              - 90
+        configs:
+          - name: "random-string-377"
+            value: "random-string-192"
+    timeoutMs: 330
+    validateOnly: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 395
+    topics:
+      - name: "random-string-517"
+        errorCode: 852
+        errorMessage: "random-string-875"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/4/baseline.yaml
@@ -1,0 +1,79 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_TOPICS"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_TOPICS"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 19
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            numPartitions: 982
+            replicationFactor: 858
+            assignments:
+              - partitionIndex: 362
+                brokerIds:
+                  - 419
+            configs:
+              - name: "random-string-46"
+                value: "random-string-342"
+        timeoutMs: 95
+        validateOnly: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 706
+        topics:
+          - name: "random-string-709"
+            errorCode: 112
+            errorMessage: "random-string-808"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 19
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        numPartitions: 982
+        replicationFactor: 858
+        assignments:
+          - partitionIndex: 362
+            brokerIds:
+              - 419
+        configs:
+          - name: "random-string-46"
+            value: "random-string-342"
+    timeoutMs: 95
+    validateOnly: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 706
+    topics:
+      - name: "random-string-709"
+        errorCode: 112
+        errorMessage: "random-string-808"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/5/baseline.yaml
@@ -1,0 +1,99 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_TOPICS"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_TOPICS"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 19
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            numPartitions: 196
+            replicationFactor: 192
+            assignments:
+              - partitionIndex: 912
+                brokerIds:
+                  - 978
+            configs:
+              - name: "random-string-732"
+                value: "random-string-866"
+        timeoutMs: 1013
+        validateOnly: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 331
+        topics:
+          - name: "my-topic"
+            errorCode: 0
+            errorMessage: ""
+            numPartitions: 291
+            replicationFactor: 102
+            configs:
+              - name: "random-string-237"
+                value: "random-string-152"
+                readOnly: false
+                configSource: 69
+                isSensitive: false
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE_CONFIGS"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 19
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        numPartitions: 196
+        replicationFactor: 192
+        assignments:
+          - partitionIndex: 912
+            brokerIds:
+              - 978
+        configs:
+          - name: "random-string-732"
+            value: "random-string-866"
+    timeoutMs: 1013
+    validateOnly: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 331
+    topics:
+      - name: "my-topic"
+        errorCode: 0
+        errorMessage: ""
+        numPartitions: 291
+        replicationFactor: 102
+        configs:
+          - name: "random-string-237"
+            value: "random-string-152"
+            readOnly: false
+            configSource: 69
+            isSensitive: false

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/6/baseline.yaml
@@ -1,0 +1,99 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_TOPICS"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_TOPICS"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 19
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            numPartitions: 572
+            replicationFactor: 640
+            assignments:
+              - partitionIndex: 591
+                brokerIds:
+                  - 607
+            configs:
+              - name: "random-string-973"
+                value: "random-string-917"
+        timeoutMs: 62
+        validateOnly: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 514
+        topics:
+          - name: "my-topic"
+            errorCode: 69
+            errorMessage: "random-string-964"
+            numPartitions: 383
+            replicationFactor: 624
+            configs:
+              - name: "random-string-596"
+                value: "random-string-1007"
+                readOnly: true
+                configSource: 96
+                isSensitive: true
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE_CONFIGS"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 19
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        numPartitions: 572
+        replicationFactor: 640
+        assignments:
+          - partitionIndex: 591
+            brokerIds:
+              - 607
+        configs:
+          - name: "random-string-973"
+            value: "random-string-917"
+    timeoutMs: 62
+    validateOnly: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 514
+    topics:
+      - name: "my-topic"
+        errorCode: 69
+        errorMessage: "random-string-964"
+        numPartitions: 383
+        replicationFactor: 624
+        configs:
+          - name: "random-string-596"
+            value: "random-string-1007"
+            readOnly: true
+            configSource: 96
+            isSensitive: true

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/7/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/7/baseline.yaml
@@ -1,0 +1,101 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_TOPICS"
+  apiVersion: 7
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_TOPICS"
+      expectedRequestVersion: 7
+      expectedRequestHeader:
+        requestApiKey: 19
+        requestApiVersion: 7
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            numPartitions: 14
+            replicationFactor: 996
+            assignments:
+              - partitionIndex: 910
+                brokerIds:
+                  - 964
+            configs:
+              - name: "random-string-21"
+                value: "random-string-457"
+        timeoutMs: 314
+        validateOnly: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 167
+        topics:
+          - name: "my-topic"
+            topicId: "6get6nl1SHiAaBAJ_3XYMw"
+            errorCode: 746
+            errorMessage: "random-string-874"
+            numPartitions: 330
+            replicationFactor: 90
+            configs:
+              - name: "random-string-170"
+                value: "random-string-623"
+                readOnly: false
+                configSource: 103
+                isSensitive: true
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE_CONFIGS"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 19
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        numPartitions: 14
+        replicationFactor: 996
+        assignments:
+          - partitionIndex: 910
+            brokerIds:
+              - 964
+        configs:
+          - name: "random-string-21"
+            value: "random-string-457"
+    timeoutMs: 314
+    validateOnly: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 167
+    topics:
+      - name: "my-topic"
+        topicId: "6get6nl1SHiAaBAJ_3XYMw"
+        errorCode: 746
+        errorMessage: "random-string-874"
+        numPartitions: 330
+        replicationFactor: 90
+        configs:
+          - name: "random-string-170"
+            value: "random-string-623"
+            readOnly: false
+            configSource: 103
+            isSensitive: true

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/1/baseline.yaml
@@ -1,0 +1,57 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DELETE_TOPICS"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "DELETE_TOPICS"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 20
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topicNames:
+          - "my-topic"
+        timeoutMs: 240
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 673
+        responses:
+          - name: "my-topic"
+            errorCode: 648
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DELETE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 20
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topicNames:
+      - "my-topic"
+    timeoutMs: 240
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 673
+    responses:
+      - name: "my-topic"
+        errorCode: 648

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/2/baseline.yaml
@@ -1,0 +1,57 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DELETE_TOPICS"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "DELETE_TOPICS"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 20
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topicNames:
+          - "my-topic"
+        timeoutMs: 490
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 824
+        responses:
+          - name: "my-topic"
+            errorCode: 891
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DELETE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 20
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topicNames:
+      - "my-topic"
+    timeoutMs: 490
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 824
+    responses:
+      - name: "my-topic"
+        errorCode: 891

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/3/baseline.yaml
@@ -1,0 +1,57 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DELETE_TOPICS"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "DELETE_TOPICS"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 20
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topicNames:
+          - "my-topic"
+        timeoutMs: 210
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 490
+        responses:
+          - name: "my-topic"
+            errorCode: 240
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DELETE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 20
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topicNames:
+      - "my-topic"
+    timeoutMs: 210
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 490
+    responses:
+      - name: "my-topic"
+        errorCode: 240

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/4/baseline.yaml
@@ -1,0 +1,57 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DELETE_TOPICS"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "DELETE_TOPICS"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 20
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topicNames:
+          - "my-topic"
+        timeoutMs: 86
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 537
+        responses:
+          - name: "my-topic"
+            errorCode: 350
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DELETE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 20
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topicNames:
+      - "my-topic"
+    timeoutMs: 86
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 537
+    responses:
+      - name: "my-topic"
+        errorCode: 350

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/5/baseline.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DELETE_TOPICS"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "DELETE_TOPICS"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 20
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topicNames:
+          - "my-topic"
+        timeoutMs: 70
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 280
+        responses:
+          - name: "my-topic"
+            errorCode: 86
+            errorMessage: "random-string-871"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DELETE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 20
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topicNames:
+      - "my-topic"
+    timeoutMs: 70
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 280
+    responses:
+      - name: "my-topic"
+        errorCode: 86
+        errorMessage: "random-string-871"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/6/baseline.yaml
@@ -1,0 +1,63 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DELETE_TOPICS"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "DELETE_TOPICS"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 20
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            topicId: "ZVa4q4iBSXSGQewb2tFCJA"
+        timeoutMs: 268
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 945
+        responses:
+          - name: "my-topic"
+            topicId: "iIEpdMZBTBua0UIkDIeF7w"
+            errorCode: 268
+            errorMessage: "my-topic"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DELETE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 20
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        topicId: "ZVa4q4iBSXSGQewb2tFCJA"
+    timeoutMs: 268
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 945
+    responses:
+      - name: "my-topic"
+        topicId: "iIEpdMZBTBua0UIkDIeF7w"
+        errorCode: 268
+        errorMessage: "my-topic"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/10/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/10/baseline.yaml
@@ -1,0 +1,111 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 10
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 10
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 10
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 556
+        maxWaitMs: 362
+        minBytes: 264
+        maxBytes: 857
+        isolationLevel: 7
+        sessionId: 182
+        sessionEpoch: 899
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 295
+                currentLeaderEpoch: 119
+                fetchOffset: 895
+                logStartOffset: 289
+                partitionMaxBytes: 182
+        forgottenTopicsData:
+          - topic: "my-topic"
+            partitions:
+              - 427
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 216
+        errorCode: 436
+        sessionId: 440
+        responses:
+          - topic: "my-topic"
+            partitions:
+              - partitionIndex: 472
+                errorCode: 159
+                highWatermark: 303
+                lastStableOffset: 889
+                logStartOffset: 769
+                abortedTransactions:
+                  - producerId: 991
+                    firstOffset: 926
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 10
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 556
+    maxWaitMs: 362
+    minBytes: 264
+    maxBytes: 857
+    isolationLevel: 7
+    sessionId: 182
+    sessionEpoch: 899
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 295
+            currentLeaderEpoch: 119
+            fetchOffset: 895
+            logStartOffset: 289
+            partitionMaxBytes: 182
+    forgottenTopicsData:
+      - topic: "my-topic"
+        partitions:
+          - 427
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 216
+    errorCode: 436
+    sessionId: 440
+    responses:
+      - topic: "my-topic"
+        partitions:
+          - partitionIndex: 472
+            errorCode: 159
+            highWatermark: 303
+            lastStableOffset: 889
+            logStartOffset: 769
+            abortedTransactions:
+              - producerId: 991
+                firstOffset: 926
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/11/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/11/baseline.yaml
@@ -1,0 +1,115 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 11
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 11
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 11
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 877
+        maxWaitMs: 1007
+        minBytes: 846
+        maxBytes: 781
+        isolationLevel: 35
+        sessionId: 597
+        sessionEpoch: 666
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 726
+                currentLeaderEpoch: 95
+                fetchOffset: 758
+                logStartOffset: 377
+                partitionMaxBytes: 448
+        forgottenTopicsData:
+          - topic: "my-topic"
+            partitions:
+              - 55
+        rackId: "random-string-755"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 471
+        errorCode: 1002
+        sessionId: 192
+        responses:
+          - topic: "my-topic"
+            partitions:
+              - partitionIndex: 173
+                errorCode: 536
+                highWatermark: 509
+                lastStableOffset: 869
+                logStartOffset: 443
+                abortedTransactions:
+                  - producerId: 629
+                    firstOffset: 410
+                preferredReadReplica: 408
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 11
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 877
+    maxWaitMs: 1007
+    minBytes: 846
+    maxBytes: 781
+    isolationLevel: 35
+    sessionId: 597
+    sessionEpoch: 666
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 726
+            currentLeaderEpoch: 95
+            fetchOffset: 758
+            logStartOffset: 377
+            partitionMaxBytes: 448
+    forgottenTopicsData:
+      - topic: "my-topic"
+        partitions:
+          - 55
+    rackId: "random-string-755"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 471
+    errorCode: 1002
+    sessionId: 192
+    responses:
+      - topic: "my-topic"
+        partitions:
+          - partitionIndex: 173
+            errorCode: 536
+            highWatermark: 509
+            lastStableOffset: 869
+            logStartOffset: 443
+            abortedTransactions:
+              - producerId: 629
+                firstOffset: 410
+            preferredReadReplica: 408
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/12/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/12/baseline.yaml
@@ -1,0 +1,117 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 12
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 12
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 66
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topic: "my-topic"
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 15
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topic: "my-topic"
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 66
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topic: "my-topic"
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 15
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topic: "my-topic"
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/4/baseline.yaml
@@ -1,0 +1,89 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 329
+        maxWaitMs: 541
+        minBytes: 678
+        maxBytes: 587
+        isolationLevel: 125
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 102
+                fetchOffset: 401
+                partitionMaxBytes: 768
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 676
+        responses:
+          - topic: "my-topic"
+            partitions:
+              - partitionIndex: 548
+                errorCode: 990
+                highWatermark: 619
+                lastStableOffset: 700
+                abortedTransactions:
+                  - producerId: 920
+                    firstOffset: 979
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 329
+    maxWaitMs: 541
+    minBytes: 678
+    maxBytes: 587
+    isolationLevel: 125
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 102
+            fetchOffset: 401
+            partitionMaxBytes: 768
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 676
+    responses:
+      - topic: "my-topic"
+        partitions:
+          - partitionIndex: 548
+            errorCode: 990
+            highWatermark: 619
+            lastStableOffset: 700
+            abortedTransactions:
+              - producerId: 920
+                firstOffset: 979
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/5/baseline.yaml
@@ -1,0 +1,93 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 162
+        maxWaitMs: 962
+        minBytes: 884
+        maxBytes: 396
+        isolationLevel: 61
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 262
+                fetchOffset: 156
+                logStartOffset: 500
+                partitionMaxBytes: 960
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 294
+        responses:
+          - topic: "my-topic"
+            partitions:
+              - partitionIndex: 591
+                errorCode: 619
+                highWatermark: 281
+                lastStableOffset: 665
+                logStartOffset: 849
+                abortedTransactions:
+                  - producerId: 264
+                    firstOffset: 393
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 162
+    maxWaitMs: 962
+    minBytes: 884
+    maxBytes: 396
+    isolationLevel: 61
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 262
+            fetchOffset: 156
+            logStartOffset: 500
+            partitionMaxBytes: 960
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 294
+    responses:
+      - topic: "my-topic"
+        partitions:
+          - partitionIndex: 591
+            errorCode: 619
+            highWatermark: 281
+            lastStableOffset: 665
+            logStartOffset: 849
+            abortedTransactions:
+              - producerId: 264
+                firstOffset: 393
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/6/baseline.yaml
@@ -1,0 +1,93 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 421
+        maxWaitMs: 340
+        minBytes: 259
+        maxBytes: 297
+        isolationLevel: 67
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 940
+                fetchOffset: 391
+                logStartOffset: 999
+                partitionMaxBytes: 998
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 874
+        responses:
+          - topic: "my-topic"
+            partitions:
+              - partitionIndex: 803
+                errorCode: 836
+                highWatermark: 353
+                lastStableOffset: 97
+                logStartOffset: 941
+                abortedTransactions:
+                  - producerId: 184
+                    firstOffset: 256
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 421
+    maxWaitMs: 340
+    minBytes: 259
+    maxBytes: 297
+    isolationLevel: 67
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 940
+            fetchOffset: 391
+            logStartOffset: 999
+            partitionMaxBytes: 998
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 874
+    responses:
+      - topic: "my-topic"
+        partitions:
+          - partitionIndex: 803
+            errorCode: 836
+            highWatermark: 353
+            lastStableOffset: 97
+            logStartOffset: 941
+            abortedTransactions:
+              - producerId: 184
+                firstOffset: 256
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/7/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/7/baseline.yaml
@@ -1,0 +1,109 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 7
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 7
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 7
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 735
+        maxWaitMs: 291
+        minBytes: 880
+        maxBytes: 623
+        isolationLevel: 50
+        sessionId: 792
+        sessionEpoch: 503
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 805
+                fetchOffset: 729
+                logStartOffset: 461
+                partitionMaxBytes: 804
+        forgottenTopicsData:
+          - topic: "my-topic"
+            partitions:
+              - 419
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 637
+        errorCode: 933
+        sessionId: 573
+        responses:
+          - topic: "my-topic"
+            partitions:
+              - partitionIndex: 94
+                errorCode: 759
+                highWatermark: 922
+                lastStableOffset: 265
+                logStartOffset: 664
+                abortedTransactions:
+                  - producerId: 12
+                    firstOffset: 766
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 735
+    maxWaitMs: 291
+    minBytes: 880
+    maxBytes: 623
+    isolationLevel: 50
+    sessionId: 792
+    sessionEpoch: 503
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 805
+            fetchOffset: 729
+            logStartOffset: 461
+            partitionMaxBytes: 804
+    forgottenTopicsData:
+      - topic: "my-topic"
+        partitions:
+          - 419
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 637
+    errorCode: 933
+    sessionId: 573
+    responses:
+      - topic: "my-topic"
+        partitions:
+          - partitionIndex: 94
+            errorCode: 759
+            highWatermark: 922
+            lastStableOffset: 265
+            logStartOffset: 664
+            abortedTransactions:
+              - producerId: 12
+                firstOffset: 766
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/8/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/8/baseline.yaml
@@ -1,0 +1,109 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 8
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 621
+        maxWaitMs: 172
+        minBytes: 285
+        maxBytes: 781
+        isolationLevel: 123
+        sessionId: 971
+        sessionEpoch: 362
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 973
+                fetchOffset: 596
+                logStartOffset: 699
+                partitionMaxBytes: 453
+        forgottenTopicsData:
+          - topic: "my-topic"
+            partitions:
+              - 927
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 753
+        errorCode: 723
+        sessionId: 984
+        responses:
+          - topic: "my-topic"
+            partitions:
+              - partitionIndex: 752
+                errorCode: 682
+                highWatermark: 750
+                lastStableOffset: 890
+                logStartOffset: 509
+                abortedTransactions:
+                  - producerId: 477
+                    firstOffset: 432
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 621
+    maxWaitMs: 172
+    minBytes: 285
+    maxBytes: 781
+    isolationLevel: 123
+    sessionId: 971
+    sessionEpoch: 362
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 973
+            fetchOffset: 596
+            logStartOffset: 699
+            partitionMaxBytes: 453
+    forgottenTopicsData:
+      - topic: "my-topic"
+        partitions:
+          - 927
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 753
+    errorCode: 723
+    sessionId: 984
+    responses:
+      - topic: "my-topic"
+        partitions:
+          - partitionIndex: 752
+            errorCode: 682
+            highWatermark: 750
+            lastStableOffset: 890
+            logStartOffset: 509
+            abortedTransactions:
+              - producerId: 477
+                firstOffset: 432
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/9/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/9/baseline.yaml
@@ -1,0 +1,111 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 9
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 12
+        maxWaitMs: 423
+        minBytes: 592
+        maxBytes: 266
+        isolationLevel: 5
+        sessionId: 786
+        sessionEpoch: 739
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 117
+                currentLeaderEpoch: 553
+                fetchOffset: 475
+                logStartOffset: 228
+                partitionMaxBytes: 342
+        forgottenTopicsData:
+          - topic: "my-topic"
+            partitions:
+              - 414
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 481
+        errorCode: 868
+        sessionId: 948
+        responses:
+          - topic: "my-topic"
+            partitions:
+              - partitionIndex: 294
+                errorCode: 351
+                highWatermark: 830
+                lastStableOffset: 34
+                logStartOffset: 155
+                abortedTransactions:
+                  - producerId: 995
+                    firstOffset: 616
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 12
+    maxWaitMs: 423
+    minBytes: 592
+    maxBytes: 266
+    isolationLevel: 5
+    sessionId: 786
+    sessionEpoch: 739
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 117
+            currentLeaderEpoch: 553
+            fetchOffset: 475
+            logStartOffset: 228
+            partitionMaxBytes: 342
+    forgottenTopicsData:
+      - topic: "my-topic"
+        partitions:
+          - 414
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 481
+    errorCode: 868
+    sessionId: 948
+    responses:
+      - topic: "my-topic"
+        partitions:
+          - partitionIndex: 294
+            errorCode: 351
+            highWatermark: 830
+            lastStableOffset: 34
+            logStartOffset: 155
+            abortedTransactions:
+              - producerId: 995
+                firstOffset: 616
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/0/baseline.yaml
@@ -1,0 +1,53 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FIND_COORDINATOR"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FIND_COORDINATOR"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 10
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        key: "random-string-715"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 4
+        nodeId: 223
+        host: "random-string-822"
+        port: 919
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 10
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    key: "random-string-715"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 4
+    nodeId: 223
+    host: "random-string-822"
+    port: 919

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/1/baseline.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FIND_COORDINATOR"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FIND_COORDINATOR"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 10
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        key: "random-string-435"
+        keyType: 34
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 49
+        errorCode: 49
+        errorMessage: "random-string-269"
+        nodeId: 511
+        host: "random-string-938"
+        port: 769
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 10
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    key: "random-string-435"
+    keyType: 34
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 49
+    errorCode: 49
+    errorMessage: "random-string-269"
+    nodeId: 511
+    host: "random-string-938"
+    port: 769

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/2/baseline.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FIND_COORDINATOR"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FIND_COORDINATOR"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 10
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        key: "random-string-600"
+        keyType: 17
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 1003
+        errorCode: 127
+        errorMessage: "random-string-922"
+        nodeId: 681
+        host: "random-string-549"
+        port: 487
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 10
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    key: "random-string-600"
+    keyType: 17
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 1003
+    errorCode: 127
+    errorMessage: "random-string-922"
+    nodeId: 681
+    host: "random-string-549"
+    port: 487

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/3/baseline.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FIND_COORDINATOR"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FIND_COORDINATOR"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 10
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        key: "random-string-480"
+        keyType: 57
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 435
+        errorCode: 722
+        errorMessage: "random-string-808"
+        nodeId: 111
+        host: "random-string-540"
+        port: 620
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 10
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    key: "random-string-480"
+    keyType: 57
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 435
+    errorCode: 722
+    errorMessage: "random-string-808"
+    nodeId: 111
+    host: "random-string-540"
+    port: 620

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/4/baseline.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FIND_COORDINATOR"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FIND_COORDINATOR"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 10
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        keyType: 55
+        coordinatorKeys:
+          - "random-string-977"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 1016
+        coordinators:
+          - key: "random-string-646"
+            nodeId: 639
+            host: "random-string-641"
+            port: 432
+            errorCode: 220
+            errorMessage: "random-string-990"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 10
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    keyType: 55
+    coordinatorKeys:
+      - "random-string-977"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 1016
+    coordinators:
+      - key: "random-string-646"
+        nodeId: 639
+        host: "random-string-641"
+        port: 432
+        errorCode: 220
+        errorMessage: "random-string-990"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/5/baseline.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FIND_COORDINATOR"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FIND_COORDINATOR"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 10
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        keyType: 81
+        coordinatorKeys:
+          - "random-string-934"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 249
+        coordinators:
+          - key: "random-string-393"
+            nodeId: 541
+            host: "random-string-482"
+            port: 519
+            errorCode: 824
+            errorMessage: "random-string-76"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 10
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    keyType: 81
+    coordinatorKeys:
+      - "random-string-934"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 249
+    coordinators:
+      - key: "random-string-393"
+        nodeId: 541
+        host: "random-string-482"
+        port: 519
+        errorCode: 824
+        errorMessage: "random-string-76"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/6/baseline.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FIND_COORDINATOR"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FIND_COORDINATOR"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 10
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        keyType: 3
+        coordinatorKeys:
+          - "random-string-191"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 804
+        coordinators:
+          - key: "random-string-70"
+            nodeId: 604
+            host: "random-string-206"
+            port: 927
+            errorCode: 368
+            errorMessage: "random-string-1003"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 10
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    keyType: 3
+    coordinatorKeys:
+      - "random-string-191"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 804
+    coordinators:
+      - key: "random-string-70"
+        nodeId: 604
+        host: "random-string-206"
+        port: 927
+        errorCode: 368
+        errorMessage: "random-string-1003"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/0/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "INIT_PRODUCER_ID"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "INIT_PRODUCER_ID"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 22
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-535"
+        transactionTimeoutMs: 506
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 289
+        errorCode: 273
+        producerId: 324
+        producerEpoch: 123
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 22
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-535"
+    transactionTimeoutMs: 506
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 289
+    errorCode: 273
+    producerId: 324
+    producerEpoch: 123

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/1/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "INIT_PRODUCER_ID"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "INIT_PRODUCER_ID"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 22
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-571"
+        transactionTimeoutMs: 1010
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 443
+        errorCode: 81
+        producerId: 640
+        producerEpoch: 120
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 22
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-571"
+    transactionTimeoutMs: 1010
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 443
+    errorCode: 81
+    producerId: 640
+    producerEpoch: 120

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/2/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "INIT_PRODUCER_ID"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "INIT_PRODUCER_ID"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 22
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-64"
+        transactionTimeoutMs: 645
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 936
+        errorCode: 414
+        producerId: 855
+        producerEpoch: 644
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 22
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-64"
+    transactionTimeoutMs: 645
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 936
+    errorCode: 414
+    producerId: 855
+    producerEpoch: 644

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/3/baseline.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "INIT_PRODUCER_ID"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "INIT_PRODUCER_ID"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 22
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-990"
+        transactionTimeoutMs: 920
+        producerId: 54
+        producerEpoch: 166
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 961
+        errorCode: 169
+        producerId: 210
+        producerEpoch: 978
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 22
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-990"
+    transactionTimeoutMs: 920
+    producerId: 54
+    producerEpoch: 166
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 961
+    errorCode: 169
+    producerId: 210
+    producerEpoch: 978

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/4/baseline.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "INIT_PRODUCER_ID"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "INIT_PRODUCER_ID"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 22
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-548"
+        transactionTimeoutMs: 700
+        producerId: 306
+        producerEpoch: 364
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 6
+        errorCode: 267
+        producerId: 803
+        producerEpoch: 88
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 22
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-548"
+    transactionTimeoutMs: 700
+    producerId: 306
+    producerEpoch: 364
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 6
+    errorCode: 267
+    producerId: 803
+    producerEpoch: 88

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/5/baseline.yaml
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "INIT_PRODUCER_ID"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "INIT_PRODUCER_ID"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 22
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-492"
+        transactionTimeoutMs: 649
+        producerId: 575
+        producerEpoch: 966
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 450
+        errorCode: 838
+        producerId: 980
+        producerEpoch: 629
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 22
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-492"
+    transactionTimeoutMs: 649
+    producerId: 575
+    producerEpoch: 966
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 450
+    errorCode: 838
+    producerId: 980
+    producerEpoch: 629

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INIT_PRODUCER_ID/6/baseline.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "INIT_PRODUCER_ID"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "INIT_PRODUCER_ID"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 22
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-619"
+        transactionTimeoutMs: 264
+        producerId: 564
+        producerEpoch: 554
+        enable2Pc: true
+        keepPreparedTxn: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 201
+        errorCode: 197
+        producerId: 712
+        producerEpoch: 773
+        ongoingTxnProducerId: 399
+        ongoingTxnProducerEpoch: 314
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 22
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-619"
+    transactionTimeoutMs: 264
+    producerId: 564
+    producerEpoch: 554
+    enable2Pc: true
+    keepPreparedTxn: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 201
+    errorCode: 197
+    producerId: 712
+    producerEpoch: 773
+    ongoingTxnProducerId: 399
+    ongoingTxnProducerEpoch: 314

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/0/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-739"
+        sessionTimeoutMs: 256
+        memberId: "random-string-541"
+        protocolType: "random-string-693"
+        protocols:
+          - name: "random-string-205"
+            metadata: !!binary |-
+              L7BsOiY=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 484
+        generationId: 614
+        protocolName: "random-string-771"
+        leader: "random-string-4"
+        memberId: "random-string-509"
+        members:
+          - memberId: "random-string-2"
+            metadata: !!binary |-
+              1Pg4axQ=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-739"
+    sessionTimeoutMs: 256
+    memberId: "random-string-541"
+    protocolType: "random-string-693"
+    protocols:
+      - name: "random-string-205"
+        metadata: !!binary |-
+          L7BsOiY=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 484
+    generationId: 614
+    protocolName: "random-string-771"
+    leader: "random-string-4"
+    memberId: "random-string-509"
+    members:
+      - memberId: "random-string-2"
+        metadata: !!binary |-
+          1Pg4axQ=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/1/baseline.yaml
@@ -1,0 +1,79 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-1023"
+        sessionTimeoutMs: 5
+        rebalanceTimeoutMs: 97
+        memberId: "random-string-184"
+        protocolType: "random-string-836"
+        protocols:
+          - name: "random-string-692"
+            metadata: !!binary |-
+              2KhN92E=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 334
+        generationId: 782
+        protocolName: "random-string-134"
+        leader: "random-string-83"
+        memberId: "random-string-686"
+        members:
+          - memberId: "random-string-450"
+            metadata: !!binary |-
+              jRyYc94=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-1023"
+    sessionTimeoutMs: 5
+    rebalanceTimeoutMs: 97
+    memberId: "random-string-184"
+    protocolType: "random-string-836"
+    protocols:
+      - name: "random-string-692"
+        metadata: !!binary |-
+          2KhN92E=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 334
+    generationId: 782
+    protocolName: "random-string-134"
+    leader: "random-string-83"
+    memberId: "random-string-686"
+    members:
+      - memberId: "random-string-450"
+        metadata: !!binary |-
+          jRyYc94=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/2/baseline.yaml
@@ -1,0 +1,81 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-941"
+        sessionTimeoutMs: 885
+        rebalanceTimeoutMs: 653
+        memberId: "random-string-803"
+        protocolType: "random-string-612"
+        protocols:
+          - name: "random-string-178"
+            metadata: !!binary |-
+              8DRBf2I=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 463
+        errorCode: 902
+        generationId: 801
+        protocolName: "random-string-939"
+        leader: "random-string-120"
+        memberId: "random-string-608"
+        members:
+          - memberId: "random-string-369"
+            metadata: !!binary |-
+              JF3/W64=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-941"
+    sessionTimeoutMs: 885
+    rebalanceTimeoutMs: 653
+    memberId: "random-string-803"
+    protocolType: "random-string-612"
+    protocols:
+      - name: "random-string-178"
+        metadata: !!binary |-
+          8DRBf2I=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 463
+    errorCode: 902
+    generationId: 801
+    protocolName: "random-string-939"
+    leader: "random-string-120"
+    memberId: "random-string-608"
+    members:
+      - memberId: "random-string-369"
+        metadata: !!binary |-
+          JF3/W64=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/3/baseline.yaml
@@ -1,0 +1,81 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-874"
+        sessionTimeoutMs: 461
+        rebalanceTimeoutMs: 759
+        memberId: "random-string-933"
+        protocolType: "random-string-771"
+        protocols:
+          - name: "random-string-12"
+            metadata: !!binary |-
+              /vbNlqI=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 202
+        errorCode: 754
+        generationId: 58
+        protocolName: "random-string-689"
+        leader: "random-string-521"
+        memberId: "random-string-356"
+        members:
+          - memberId: "random-string-920"
+            metadata: !!binary |-
+              rKWUtyE=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-874"
+    sessionTimeoutMs: 461
+    rebalanceTimeoutMs: 759
+    memberId: "random-string-933"
+    protocolType: "random-string-771"
+    protocols:
+      - name: "random-string-12"
+        metadata: !!binary |-
+          /vbNlqI=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 202
+    errorCode: 754
+    generationId: 58
+    protocolName: "random-string-689"
+    leader: "random-string-521"
+    memberId: "random-string-356"
+    members:
+      - memberId: "random-string-920"
+        metadata: !!binary |-
+          rKWUtyE=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/4/baseline.yaml
@@ -1,0 +1,81 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-922"
+        sessionTimeoutMs: 346
+        rebalanceTimeoutMs: 1002
+        memberId: "random-string-819"
+        protocolType: "random-string-265"
+        protocols:
+          - name: "random-string-94"
+            metadata: !!binary |-
+              mPUDDZg=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 684
+        errorCode: 70
+        generationId: 947
+        protocolName: "random-string-871"
+        leader: "random-string-373"
+        memberId: "random-string-538"
+        members:
+          - memberId: "random-string-808"
+            metadata: !!binary |-
+              7DvzO3Y=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-922"
+    sessionTimeoutMs: 346
+    rebalanceTimeoutMs: 1002
+    memberId: "random-string-819"
+    protocolType: "random-string-265"
+    protocols:
+      - name: "random-string-94"
+        metadata: !!binary |-
+          mPUDDZg=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 684
+    errorCode: 70
+    generationId: 947
+    protocolName: "random-string-871"
+    leader: "random-string-373"
+    memberId: "random-string-538"
+    members:
+      - memberId: "random-string-808"
+        metadata: !!binary |-
+          7DvzO3Y=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/5/baseline.yaml
@@ -1,0 +1,85 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-483"
+        sessionTimeoutMs: 432
+        rebalanceTimeoutMs: 705
+        memberId: "random-string-322"
+        groupInstanceId: "random-string-181"
+        protocolType: "random-string-103"
+        protocols:
+          - name: "random-string-723"
+            metadata: !!binary |-
+              PeLyIH0=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 999
+        errorCode: 251
+        generationId: 896
+        protocolName: "random-string-402"
+        leader: "random-string-659"
+        memberId: "random-string-531"
+        members:
+          - memberId: "random-string-941"
+            groupInstanceId: "random-string-995"
+            metadata: !!binary |-
+              ePha8mA=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-483"
+    sessionTimeoutMs: 432
+    rebalanceTimeoutMs: 705
+    memberId: "random-string-322"
+    groupInstanceId: "random-string-181"
+    protocolType: "random-string-103"
+    protocols:
+      - name: "random-string-723"
+        metadata: !!binary |-
+          PeLyIH0=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 999
+    errorCode: 251
+    generationId: 896
+    protocolName: "random-string-402"
+    leader: "random-string-659"
+    memberId: "random-string-531"
+    members:
+      - memberId: "random-string-941"
+        groupInstanceId: "random-string-995"
+        metadata: !!binary |-
+          ePha8mA=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/6/baseline.yaml
@@ -1,0 +1,85 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-904"
+        sessionTimeoutMs: 509
+        rebalanceTimeoutMs: 177
+        memberId: "random-string-682"
+        groupInstanceId: "random-string-477"
+        protocolType: "random-string-909"
+        protocols:
+          - name: "random-string-890"
+            metadata: !!binary |-
+              7gonQMQ=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 308
+        errorCode: 283
+        generationId: 388
+        protocolName: "random-string-643"
+        leader: "random-string-51"
+        memberId: "random-string-939"
+        members:
+          - memberId: "random-string-186"
+            groupInstanceId: "random-string-802"
+            metadata: !!binary |-
+              v8UkeQ8=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-904"
+    sessionTimeoutMs: 509
+    rebalanceTimeoutMs: 177
+    memberId: "random-string-682"
+    groupInstanceId: "random-string-477"
+    protocolType: "random-string-909"
+    protocols:
+      - name: "random-string-890"
+        metadata: !!binary |-
+          7gonQMQ=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 308
+    errorCode: 283
+    generationId: 388
+    protocolName: "random-string-643"
+    leader: "random-string-51"
+    memberId: "random-string-939"
+    members:
+      - memberId: "random-string-186"
+        groupInstanceId: "random-string-802"
+        metadata: !!binary |-
+          v8UkeQ8=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/7/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/7/baseline.yaml
@@ -1,0 +1,87 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 7
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 7
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 7
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-752"
+        sessionTimeoutMs: 753
+        rebalanceTimeoutMs: 984
+        memberId: "random-string-10"
+        groupInstanceId: "random-string-434"
+        protocolType: "random-string-109"
+        protocols:
+          - name: "random-string-857"
+            metadata: !!binary |-
+              9GZLx1A=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 24
+        errorCode: 986
+        generationId: 773
+        protocolType: "random-string-536"
+        protocolName: "random-string-557"
+        leader: "random-string-638"
+        memberId: "random-string-1015"
+        members:
+          - memberId: "random-string-225"
+            groupInstanceId: "random-string-220"
+            metadata: !!binary |-
+              zC7IcwI=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-752"
+    sessionTimeoutMs: 753
+    rebalanceTimeoutMs: 984
+    memberId: "random-string-10"
+    groupInstanceId: "random-string-434"
+    protocolType: "random-string-109"
+    protocols:
+      - name: "random-string-857"
+        metadata: !!binary |-
+          9GZLx1A=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 24
+    errorCode: 986
+    generationId: 773
+    protocolType: "random-string-536"
+    protocolName: "random-string-557"
+    leader: "random-string-638"
+    memberId: "random-string-1015"
+    members:
+      - memberId: "random-string-225"
+        groupInstanceId: "random-string-220"
+        metadata: !!binary |-
+          zC7IcwI=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/8/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/8/baseline.yaml
@@ -1,0 +1,89 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 8
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-868"
+        sessionTimeoutMs: 34
+        rebalanceTimeoutMs: 186
+        memberId: "random-string-616"
+        groupInstanceId: "random-string-57"
+        protocolType: "random-string-828"
+        protocols:
+          - name: "random-string-209"
+            metadata: !!binary |-
+              4zPnc18=
+        reason: "random-string-830"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 187
+        errorCode: 437
+        generationId: 981
+        protocolType: "random-string-940"
+        protocolName: "random-string-635"
+        leader: "random-string-842"
+        memberId: "random-string-942"
+        members:
+          - memberId: "random-string-338"
+            groupInstanceId: "random-string-625"
+            metadata: !!binary |-
+              geEGAHI=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-868"
+    sessionTimeoutMs: 34
+    rebalanceTimeoutMs: 186
+    memberId: "random-string-616"
+    groupInstanceId: "random-string-57"
+    protocolType: "random-string-828"
+    protocols:
+      - name: "random-string-209"
+        metadata: !!binary |-
+          4zPnc18=
+    reason: "random-string-830"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 187
+    errorCode: 437
+    generationId: 981
+    protocolType: "random-string-940"
+    protocolName: "random-string-635"
+    leader: "random-string-842"
+    memberId: "random-string-942"
+    members:
+      - memberId: "random-string-338"
+        groupInstanceId: "random-string-625"
+        metadata: !!binary |-
+          geEGAHI=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/9/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/JOIN_GROUP/9/baseline.yaml
@@ -1,0 +1,91 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 9
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "JOIN_GROUP"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 11
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-898"
+        sessionTimeoutMs: 948
+        rebalanceTimeoutMs: 16
+        memberId: "random-string-294"
+        groupInstanceId: "random-string-155"
+        protocolType: "random-string-573"
+        protocols:
+          - name: "random-string-66"
+            metadata: !!binary |-
+              FjPpKJY=
+        reason: "random-string-980"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 42
+        errorCode: 786
+        generationId: 805
+        protocolType: "random-string-874"
+        protocolName: "random-string-408"
+        leader: "random-string-199"
+        skipAssignment: true
+        memberId: "random-string-677"
+        members:
+          - memberId: "random-string-815"
+            groupInstanceId: "random-string-895"
+            metadata: !!binary |-
+              97dM46k=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-898"
+    sessionTimeoutMs: 948
+    rebalanceTimeoutMs: 16
+    memberId: "random-string-294"
+    groupInstanceId: "random-string-155"
+    protocolType: "random-string-573"
+    protocols:
+      - name: "random-string-66"
+        metadata: !!binary |-
+          FjPpKJY=
+    reason: "random-string-980"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 42
+    errorCode: 786
+    generationId: 805
+    protocolType: "random-string-874"
+    protocolName: "random-string-408"
+    leader: "random-string-199"
+    skipAssignment: true
+    memberId: "random-string-677"
+    members:
+      - memberId: "random-string-815"
+        groupInstanceId: "random-string-895"
+        metadata: !!binary |-
+          97dM46k=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/1/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 440
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 1002
+                timestamp: 410
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 22
+                errorCode: 947
+                timestamp: 202
+                offset: 863
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 440
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 1002
+            timestamp: 410
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 22
+            errorCode: 947
+            timestamp: 202
+            offset: 863

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/10/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/10/baseline.yaml
@@ -1,0 +1,79 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 10
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 10
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 10
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 674
+        isolationLevel: 119
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 342
+                currentLeaderEpoch: 635
+                timestamp: 903
+        timeoutMs: 563
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 803
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 955
+                errorCode: 272
+                timestamp: 535
+                offset: 322
+                leaderEpoch: 274
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 10
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 674
+    isolationLevel: 119
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 342
+            currentLeaderEpoch: 635
+            timestamp: 903
+    timeoutMs: 563
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 803
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 955
+            errorCode: 272
+            timestamp: 535
+            offset: 322
+            leaderEpoch: 274

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/2/baseline.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 629
+        isolationLevel: 15
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 671
+                timestamp: 832
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 224
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 239
+                errorCode: 843
+                timestamp: 203
+                offset: 1
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 629
+    isolationLevel: 15
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 671
+            timestamp: 832
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 224
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 239
+            errorCode: 843
+            timestamp: 203
+            offset: 1

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/3/baseline.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 530
+        isolationLevel: 91
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 173
+                timestamp: 424
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 762
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 581
+                errorCode: 273
+                timestamp: 696
+                offset: 721
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 530
+    isolationLevel: 91
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 173
+            timestamp: 424
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 762
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 581
+            errorCode: 273
+            timestamp: 696
+            offset: 721

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/4/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 200
+        isolationLevel: 27
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 682
+                currentLeaderEpoch: 211
+                timestamp: 471
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 275
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 629
+                errorCode: 29
+                timestamp: 646
+                offset: 586
+                leaderEpoch: 470
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 200
+    isolationLevel: 27
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 682
+            currentLeaderEpoch: 211
+            timestamp: 471
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 275
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 629
+            errorCode: 29
+            timestamp: 646
+            offset: 586
+            leaderEpoch: 470

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/5/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 62
+        isolationLevel: 84
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 287
+                currentLeaderEpoch: 673
+                timestamp: 6
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 799
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 481
+                errorCode: 280
+                timestamp: 620
+                offset: 695
+                leaderEpoch: 50
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 62
+    isolationLevel: 84
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 287
+            currentLeaderEpoch: 673
+            timestamp: 6
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 799
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 481
+            errorCode: 280
+            timestamp: 620
+            offset: 695
+            leaderEpoch: 50

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/6/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 841
+        isolationLevel: 40
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 596
+                currentLeaderEpoch: 479
+                timestamp: 22
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 397
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 747
+                errorCode: 896
+                timestamp: 195
+                offset: 491
+                leaderEpoch: 938
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 841
+    isolationLevel: 40
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 596
+            currentLeaderEpoch: 479
+            timestamp: 22
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 397
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 747
+            errorCode: 896
+            timestamp: 195
+            offset: 491
+            leaderEpoch: 938

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/7/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/7/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 7
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 7
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 7
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 491
+        isolationLevel: 124
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 934
+                currentLeaderEpoch: 210
+                timestamp: 885
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 773
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 40
+                errorCode: 864
+                timestamp: 810
+                offset: 533
+                leaderEpoch: 738
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 491
+    isolationLevel: 124
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 934
+            currentLeaderEpoch: 210
+            timestamp: 885
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 773
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 40
+            errorCode: 864
+            timestamp: 810
+            offset: 533
+            leaderEpoch: 738

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/8/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/8/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 8
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 85
+        isolationLevel: 101
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 751
+                currentLeaderEpoch: 698
+                timestamp: 301
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 469
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 946
+                errorCode: 828
+                timestamp: 978
+                offset: 575
+                leaderEpoch: 843
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 85
+    isolationLevel: 101
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 751
+            currentLeaderEpoch: 698
+            timestamp: 301
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 469
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 946
+            errorCode: 828
+            timestamp: 978
+            offset: 575
+            leaderEpoch: 843

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/9/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_OFFSETS/9/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_OFFSETS"
+  apiVersion: 9
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_OFFSETS"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 2
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 715
+        isolationLevel: 20
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 848
+                currentLeaderEpoch: 485
+                timestamp: 257
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 815
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 639
+                errorCode: 264
+                timestamp: 635
+                offset: 181
+                leaderEpoch: 687
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 2
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 715
+    isolationLevel: 20
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 848
+            currentLeaderEpoch: 485
+            timestamp: 257
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 815
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 639
+            errorCode: 264
+            timestamp: 635
+            offset: 181
+            leaderEpoch: 687

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/0/baseline.yaml
@@ -1,0 +1,133 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/1/baseline.yaml
@@ -1,0 +1,136 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            topicAuthorizedOperations: 760
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/baseline.yaml
@@ -1,0 +1,152 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 10
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 10
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 10
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: true
+        includeClusterAuthorizedOperations: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 760
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        clusterAuthorizedOperations: 760
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 10
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: true
+    includeClusterAuthorizedOperations: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 760
+    clusterAuthorizedOperations: 0

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/cluster-authorized-ops-downstream-less-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/cluster-authorized-ops-downstream-less-permissive.yaml
@@ -1,0 +1,162 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 10
+  scenario: "cluster authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 10
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 10
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 760
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        # DESCRIBE bit set
+        clusterAuthorizedOperations: 4
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+      # DESCRIBE + CREATE allowed
+      - subject: "alice"
+        resourceName: ""
+        resourceClass: "CLUSTER"
+        resourceType: "DESCRIBE"
+      - subject: "alice"
+        resourceName: ""
+        resourceClass: "CLUSTER"
+        resourceType: "CREATE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 10
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 760
+    clusterAuthorizedOperations: 4

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/cluster-authorized-ops-downstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/cluster-authorized-ops-downstream-more-permissive.yaml
@@ -1,0 +1,158 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 10
+  scenario: "cluster authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 10
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 10
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 760
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        # DESCRIBE+CREATE bit set
+        clusterAuthorizedOperations: 5
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+      # DESCRIBE allowed
+      - subject: "alice"
+        resourceName: ""
+        resourceClass: "CLUSTER"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 10
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 760
+    clusterAuthorizedOperations: 4

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/topic-authorized-ops-downstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/topic-authorized-ops-downstream-more-permissive.yaml
@@ -1,0 +1,154 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 10
+  scenario: "topic authorized ops - downstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 10
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 10
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            # READ+DESCRIBE bitset
+            topicAuthorizedOperations: 264
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        clusterAuthorizedOperations: 0
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 10
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE bitset
+        topicAuthorizedOperations: 256
+    clusterAuthorizedOperations: 0

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/topic-authorized-ops-upstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/10/topic-authorized-ops-upstream-more-permissive.yaml
@@ -1,0 +1,154 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 10
+  scenario: "topic authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 10
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 10
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            # DESCRIBE+READ+WRITE+CREATE bitset
+            topicAuthorizedOperations: 312
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        clusterAuthorizedOperations: 0
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 10
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE+CREATE bitset
+        topicAuthorizedOperations: 288
+    clusterAuthorizedOperations: 0

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/11/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/11/baseline.yaml
@@ -1,0 +1,148 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 11
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "3txkyGngTyeoEZrr__DC7w"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 11
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 11
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 760
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 11
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "3txkyGngTyeoEZrr__DC7w"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 760

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/11/topic-authorized-ops-downstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/11/topic-authorized-ops-downstream-more-permissive.yaml
@@ -1,0 +1,150 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 11
+  scenario: "topic authorized ops - downstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 11
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 11
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            # READ+DESCRIBE bitset
+            topicAuthorizedOperations: 264
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 11
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE bitset
+        topicAuthorizedOperations: 256

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/11/topic-authorized-ops-upstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/11/topic-authorized-ops-upstream-more-permissive.yaml
@@ -1,0 +1,150 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 11
+  scenario: "topic authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 11
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 11
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            # DESCRIBE+READ+WRITE+CREATE bitset
+            topicAuthorizedOperations: 312
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 11
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE+CREATE bitset
+        topicAuthorizedOperations: 288

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/12/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/12/baseline.yaml
@@ -1,0 +1,148 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 12
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "Xn83BxP-S4C8MqoMjIf6uw"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 12
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 760
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "Xn83BxP-S4C8MqoMjIf6uw"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 760

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/12/topic-authorized-ops-downstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/12/topic-authorized-ops-downstream-more-permissive.yaml
@@ -1,0 +1,150 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 12
+  scenario: "topic authorized ops - downstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 12
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            # READ+DESCRIBE bitset
+            topicAuthorizedOperations: 264
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE bitset
+        topicAuthorizedOperations: 256

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/12/topic-authorized-ops-upstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/12/topic-authorized-ops-upstream-more-permissive.yaml
@@ -1,0 +1,150 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 12
+  scenario: "topic authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 12
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            # DESCRIBE+READ+WRITE+CREATE bitset
+            topicAuthorizedOperations: 312
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE+CREATE bitset
+        topicAuthorizedOperations: 288

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/baseline.yaml
@@ -1,0 +1,149 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 13
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "e8MvPJPGSteB1fKbMEji0w"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 760
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "e8MvPJPGSteB1fKbMEji0w"
+        name: "my-topic"
+    allowAutoTopicCreation: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 760
+    errorCode: 1003

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/topic-authorized-ops-downstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/topic-authorized-ops-downstream-more-permissive.yaml
@@ -1,0 +1,151 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 13
+  scenario: "topic authorized ops - downstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            # READ+DESCRIBE bitset
+            topicAuthorizedOperations: 264
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE bitset
+        topicAuthorizedOperations: 256
+    errorCode: 1003

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/topic-authorized-ops-upstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/topic-authorized-ops-upstream-more-permissive.yaml
@@ -1,0 +1,151 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 13
+  scenario: "topic authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: [ ]
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            # DESCRIBE+READ+WRITE+CREATE bitset
+            topicAuthorizedOperations: 312
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "cwd1urkUQkmOMDQ5k5jKug"
+        name: "my-topic"
+    allowAutoTopicCreation: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE+CREATE bitset
+        topicAuthorizedOperations: 288
+    errorCode: 1003

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/2/baseline.yaml
@@ -1,0 +1,133 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 706
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/3/baseline.yaml
@@ -1,0 +1,138 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 706
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/4/baseline.yaml
@@ -1,0 +1,98 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/5/baseline.yaml
@@ -1,0 +1,142 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/6/baseline.yaml
@@ -1,0 +1,100 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/7/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/7/baseline.yaml
@@ -1,0 +1,143 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 7
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 7
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 7
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/baseline.yaml
@@ -1,0 +1,151 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 8
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: true
+        includeClusterAuthorizedOperations: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 760
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        clusterAuthorizedOperations: 760
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: true
+    includeClusterAuthorizedOperations: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 760
+    clusterAuthorizedOperations: 0

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/cluster-authorized-ops-downstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/cluster-authorized-ops-downstream-more-permissive.yaml
@@ -1,0 +1,120 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 8
+  scenario: "cluster authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "cluster-id"
+        controllerId: 892
+        # DESCRIBE bit set
+        clusterAuthorizedOperations: 4
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+      # DESCRIBE + CREATE allowed
+      - subject: "alice"
+        resourceName: ""
+        resourceClass: "CLUSTER"
+        resourceType: "DESCRIBE"
+      - subject: "alice"
+        resourceName: ""
+        resourceClass: "CLUSTER"
+        resourceType: "CREATE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "cluster-id"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 769
+    # DESCRIBE only
+    clusterAuthorizedOperations: 4

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/cluster-authorized-ops-upstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/cluster-authorized-ops-upstream-more-permissive.yaml
@@ -1,0 +1,116 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 8
+  scenario: "cluster authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "cluster-id"
+        controllerId: 892
+        # DESCRIBE + CREATE bit set
+        clusterAuthorizedOperations: 5
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+        # only DESCRIBE allowed
+      - subject: "alice"
+        resourceName: ""
+        resourceClass: "CLUSTER"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "cluster-id"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 769
+    # DESCRIBE only
+    clusterAuthorizedOperations: 4

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/topic-authorized-ops-downstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/topic-authorized-ops-downstream-more-permissive.yaml
@@ -1,0 +1,111 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 8
+  scenario: "topic authorized ops - downstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "cluster-id"
+        controllerId: 892
+        clusterAuthorizedOperations: 1
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            # READ+DESCRIBE bitset
+            topicAuthorizedOperations: 264
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "cluster-id"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE bitset
+        topicAuthorizedOperations: 256
+    clusterAuthorizedOperations: 1

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/topic-authorized-ops-upstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/8/topic-authorized-ops-upstream-more-permissive.yaml
@@ -1,0 +1,111 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 8
+  scenario: "topic authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "cluster-id"
+        controllerId: 892
+        clusterAuthorizedOperations: 1
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            # DESCRIBE+READ+WRITE+CREATE bitset
+            topicAuthorizedOperations: 312
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "cluster-id"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE+CREATE bitset
+        topicAuthorizedOperations: 288
+    clusterAuthorizedOperations: 1

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/baseline.yaml
@@ -1,0 +1,151 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 9
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: true
+        includeClusterAuthorizedOperations: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            topicAuthorizedOperations: 760
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+        clusterAuthorizedOperations: 760
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: true
+    includeClusterAuthorizedOperations: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 760
+    clusterAuthorizedOperations: 0

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/cluster-authorized-ops-downstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/cluster-authorized-ops-downstream-more-permissive.yaml
@@ -1,0 +1,120 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 9
+  scenario: "cluster authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "cluster-id"
+        controllerId: 892
+        # DESCRIBE bit set
+        clusterAuthorizedOperations: 4
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+      # DESCRIBE + CREATE allowed
+      - subject: "alice"
+        resourceName: ""
+        resourceClass: "CLUSTER"
+        resourceType: "DESCRIBE"
+      - subject: "alice"
+        resourceName: ""
+        resourceClass: "CLUSTER"
+        resourceType: "CREATE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "cluster-id"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 769
+    # DESCRIBE only
+    clusterAuthorizedOperations: 4

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/cluster-authorized-ops-upstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/cluster-authorized-ops-upstream-more-permissive.yaml
@@ -1,0 +1,116 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 9
+  scenario: "cluster authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "cluster-id"
+        controllerId: 892
+        # DESCRIBE + CREATE bit set
+        clusterAuthorizedOperations: 5
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            topicAuthorizedOperations: 769
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+        # only DESCRIBE allowed
+      - subject: "alice"
+        resourceName: ""
+        resourceClass: "CLUSTER"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "cluster-id"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        topicAuthorizedOperations: 769
+    # DESCRIBE only
+    clusterAuthorizedOperations: 4

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/topic-authorized-ops-downstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/topic-authorized-ops-downstream-more-permissive.yaml
@@ -1,0 +1,111 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 9
+  scenario: "topic authorized ops - downstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "cluster-id"
+        controllerId: 892
+        clusterAuthorizedOperations: 1
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            # READ+DESCRIBE bitset
+            topicAuthorizedOperations: 264
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "cluster-id"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE bitset
+        topicAuthorizedOperations: 256
+    clusterAuthorizedOperations: 1

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/topic-authorized-ops-upstream-more-permissive.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/9/topic-authorized-ops-upstream-more-permissive.yaml
@@ -1,0 +1,111 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 9
+  scenario: "topic authorized ops - upstream more permissive"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+        allowAutoTopicCreation: false
+        includeClusterAuthorizedOperations: false
+        includeTopicAuthorizedOperations: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "cluster-id"
+        controllerId: 892
+        clusterAuthorizedOperations: 1
+        topics:
+          - errorCode: 820
+            name: "my-topic"
+            topicId: "u0gwV8JNSUqcw-cK7k6TJA"
+            isInternal: false
+            partitions:
+              - errorCode: 922
+                partitionIndex: 1006
+                leaderId: 773
+                leaderEpoch: 652
+                replicaNodes:
+                  - 387
+                isrNodes:
+                  - 647
+                offlineReplicas:
+                  - 421
+            # DESCRIBE+READ+WRITE+CREATE bitset
+            topicAuthorizedOperations: 312
+        errorCode: 1003
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+    allowAutoTopicCreation: false
+    includeClusterAuthorizedOperations: false
+    includeTopicAuthorizedOperations: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+      - nodeId: 179
+        host: "random-string-71"
+        port: 176
+        rack: "random-string-836"
+    clusterId: "cluster-id"
+    controllerId: 892
+    topics:
+      - errorCode: 820
+        name: "my-topic"
+        isInternal: false
+        partitions:
+          - errorCode: 922
+            partitionIndex: 1006
+            leaderId: 773
+            leaderEpoch: 652
+            replicaNodes:
+              - 387
+            isrNodes:
+              - 647
+            offlineReplicas:
+              - 421
+        # DESCRIBE+CREATE bitset
+        topicAuthorizedOperations: 288
+    clusterAuthorizedOperations: 1

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/2/baseline.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_COMMIT"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_COMMIT"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 8
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-825"
+        generationIdOrMemberEpoch: 751
+        memberId: "random-string-662"
+        retentionTimeMs: 291
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 110
+                committedOffset: 416
+                committedMetadata: "random-string-604"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 422
+                errorCode: 14
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 8
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-825"
+    generationIdOrMemberEpoch: 751
+    memberId: "random-string-662"
+    retentionTimeMs: 291
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 110
+            committedOffset: 416
+            committedMetadata: "random-string-604"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 422
+            errorCode: 14

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/3/baseline.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_COMMIT"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_COMMIT"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 8
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-300"
+        generationIdOrMemberEpoch: 263
+        memberId: "random-string-194"
+        retentionTimeMs: 631
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 528
+                committedOffset: 730
+                committedMetadata: "random-string-116"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 1016
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 743
+                errorCode: 373
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 8
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-300"
+    generationIdOrMemberEpoch: 263
+    memberId: "random-string-194"
+    retentionTimeMs: 631
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 528
+            committedOffset: 730
+            committedMetadata: "random-string-116"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 1016
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 743
+            errorCode: 373

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/4/baseline.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_COMMIT"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_COMMIT"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 8
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-667"
+        generationIdOrMemberEpoch: 317
+        memberId: "random-string-335"
+        retentionTimeMs: 896
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 70
+                committedOffset: 255
+                committedMetadata: "random-string-203"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 368
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 625
+                errorCode: 595
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 8
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-667"
+    generationIdOrMemberEpoch: 317
+    memberId: "random-string-335"
+    retentionTimeMs: 896
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 70
+            committedOffset: 255
+            committedMetadata: "random-string-203"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 368
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 625
+            errorCode: 595

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/5/baseline.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_COMMIT"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_COMMIT"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 8
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-783"
+        generationIdOrMemberEpoch: 832
+        memberId: "random-string-672"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 118
+                committedOffset: 628
+                committedMetadata: "random-string-763"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 647
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 313
+                errorCode: 547
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 8
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-783"
+    generationIdOrMemberEpoch: 832
+    memberId: "random-string-672"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 118
+            committedOffset: 628
+            committedMetadata: "random-string-763"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 647
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 313
+            errorCode: 547

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/6/baseline.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_COMMIT"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_COMMIT"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 8
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-282"
+        generationIdOrMemberEpoch: 589
+        memberId: "random-string-500"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 668
+                committedOffset: 661
+                committedLeaderEpoch: 365
+                committedMetadata: "random-string-363"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 88
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 617
+                errorCode: 800
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 8
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-282"
+    generationIdOrMemberEpoch: 589
+    memberId: "random-string-500"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 668
+            committedOffset: 661
+            committedLeaderEpoch: 365
+            committedMetadata: "random-string-363"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 88
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 617
+            errorCode: 800

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/7/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/7/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_COMMIT"
+  apiVersion: 7
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_COMMIT"
+      expectedRequestVersion: 7
+      expectedRequestHeader:
+        requestApiKey: 8
+        requestApiVersion: 7
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-605"
+        generationIdOrMemberEpoch: 704
+        memberId: "random-string-138"
+        groupInstanceId: "random-string-191"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 517
+                committedOffset: 208
+                committedLeaderEpoch: 831
+                committedMetadata: "random-string-193"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 43
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 372
+                errorCode: 46
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 8
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-605"
+    generationIdOrMemberEpoch: 704
+    memberId: "random-string-138"
+    groupInstanceId: "random-string-191"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 517
+            committedOffset: 208
+            committedLeaderEpoch: 831
+            committedMetadata: "random-string-193"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 43
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 372
+            errorCode: 46

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/8/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/8/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_COMMIT"
+  apiVersion: 8
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_COMMIT"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 8
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-414"
+        generationIdOrMemberEpoch: 21
+        memberId: "random-string-3"
+        groupInstanceId: "random-string-122"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 856
+                committedOffset: 911
+                committedLeaderEpoch: 334
+                committedMetadata: "random-string-621"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 503
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 363
+                errorCode: 249
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 8
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-414"
+    generationIdOrMemberEpoch: 21
+    memberId: "random-string-3"
+    groupInstanceId: "random-string-122"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 856
+            committedOffset: 911
+            committedLeaderEpoch: 334
+            committedMetadata: "random-string-621"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 503
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 363
+            errorCode: 249

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/9/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_COMMIT/9/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_COMMIT"
+  apiVersion: 9
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_COMMIT"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 8
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-600"
+        generationIdOrMemberEpoch: 957
+        memberId: "random-string-816"
+        groupInstanceId: "random-string-577"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 61
+                committedOffset: 825
+                committedLeaderEpoch: 251
+                committedMetadata: "random-string-0"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 808
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 399
+                errorCode: 94
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 8
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-600"
+    generationIdOrMemberEpoch: 957
+    memberId: "random-string-816"
+    groupInstanceId: "random-string-577"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 61
+            committedOffset: 825
+            committedLeaderEpoch: 251
+            committedMetadata: "random-string-0"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 808
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 399
+            errorCode: 94

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_DELETE/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_DELETE/0/baseline.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_DELETE"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_DELETE"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 47
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "my-group"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 1
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 0
+        throttleTimeMs: 52
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 1
+                errorCode: 0
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 47
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "my-group"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 1
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 0
+    throttleTimeMs: 52
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 1
+            errorCode: 0

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/1/baseline.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FETCH"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FETCH"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 9
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-721"
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 180
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 193
+                committedOffset: 836
+                metadata: "random-string-135"
+                errorCode: 283
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 9
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-721"
+    topics:
+      - name: "my-topic"
+        partitionIndexes:
+          - 180
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 193
+            committedOffset: 836
+            metadata: "random-string-135"
+            errorCode: 283

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/2/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FETCH"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FETCH"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 9
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-978"
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 822
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 1023
+                committedOffset: 679
+                metadata: "random-string-988"
+                errorCode: 511
+        errorCode: 173
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 9
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-978"
+    topics:
+      - name: "my-topic"
+        partitionIndexes:
+          - 822
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 1023
+            committedOffset: 679
+            metadata: "random-string-988"
+            errorCode: 511
+    errorCode: 173

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/3/baseline.yaml
@@ -1,0 +1,71 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FETCH"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FETCH"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 9
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-223"
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 49
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 72
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 767
+                committedOffset: 48
+                metadata: "random-string-538"
+                errorCode: 999
+        errorCode: 693
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 9
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-223"
+    topics:
+      - name: "my-topic"
+        partitionIndexes:
+          - 49
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 72
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 767
+            committedOffset: 48
+            metadata: "random-string-538"
+            errorCode: 999
+    errorCode: 693

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/4/baseline.yaml
@@ -1,0 +1,71 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FETCH"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FETCH"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 9
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-269"
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 511
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 811
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 369
+                committedOffset: 788
+                metadata: "random-string-48"
+                errorCode: 826
+        errorCode: 432
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 9
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-269"
+    topics:
+      - name: "my-topic"
+        partitionIndexes:
+          - 511
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 811
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 369
+            committedOffset: 788
+            metadata: "random-string-48"
+            errorCode: 826
+    errorCode: 432

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/5/baseline.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FETCH"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FETCH"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 9
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-769"
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 127
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 819
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 122
+                committedOffset: 407
+                committedLeaderEpoch: 659
+                metadata: "random-string-834"
+                errorCode: 10
+        errorCode: 693
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 9
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-769"
+    topics:
+      - name: "my-topic"
+        partitionIndexes:
+          - 127
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 819
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 122
+            committedOffset: 407
+            committedLeaderEpoch: 659
+            metadata: "random-string-834"
+            errorCode: 10
+    errorCode: 693

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/6/baseline.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FETCH"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FETCH"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 9
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-922"
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 681
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 383
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 739
+                committedOffset: 938
+                committedLeaderEpoch: 14
+                metadata: "random-string-489"
+                errorCode: 227
+        errorCode: 996
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 9
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-922"
+    topics:
+      - name: "my-topic"
+        partitionIndexes:
+          - 681
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 383
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 739
+            committedOffset: 938
+            committedLeaderEpoch: 14
+            metadata: "random-string-489"
+            errorCode: 227
+    errorCode: 996

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/7/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/7/baseline.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FETCH"
+  apiVersion: 7
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FETCH"
+      expectedRequestVersion: 7
+      expectedRequestHeader:
+        requestApiKey: 9
+        requestApiVersion: 7
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-487"
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 808
+        requireStable: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 961
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 168
+                committedOffset: 970
+                committedLeaderEpoch: 485
+                metadata: "random-string-122"
+                errorCode: 162
+        errorCode: 17
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 9
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-487"
+    topics:
+      - name: "my-topic"
+        partitionIndexes:
+          - 808
+    requireStable: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 961
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 168
+            committedOffset: 970
+            committedLeaderEpoch: 485
+            metadata: "random-string-122"
+            errorCode: 162
+    errorCode: 17

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/8/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/8/baseline.yaml
@@ -1,0 +1,81 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FETCH"
+  apiVersion: 8
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FETCH"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 9
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groups:
+          - groupId: "random-string-540"
+            topics:
+              - name: "my-topic"
+                partitionIndexes:
+                  - 620
+        requireStable: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 220
+        groups:
+          - groupId: "random-string-107"
+            topics:
+              - name: "my-topic"
+                partitions:
+                  - partitionIndex: 344
+                    committedOffset: 888
+                    committedLeaderEpoch: 425
+                    metadata: "random-string-490"
+                    errorCode: 23
+            errorCode: 642
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 9
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groups:
+      - groupId: "random-string-540"
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 620
+    requireStable: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 220
+    groups:
+      - groupId: "random-string-107"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 344
+                committedOffset: 888
+                committedLeaderEpoch: 425
+                metadata: "random-string-490"
+                errorCode: 23
+        errorCode: 642

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/9/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FETCH/9/baseline.yaml
@@ -1,0 +1,85 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FETCH"
+  apiVersion: 9
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FETCH"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 9
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groups:
+          - groupId: "random-string-220"
+            memberId: "random-string-641"
+            memberEpoch: 990
+            topics:
+              - name: "my-topic"
+                partitionIndexes:
+                  - 639
+        requireStable: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 712
+        groups:
+          - groupId: "random-string-750"
+            topics:
+              - name: "my-topic"
+                partitions:
+                  - partitionIndex: 65
+                    committedOffset: 845
+                    committedLeaderEpoch: 240
+                    metadata: "random-string-576"
+                    errorCode: 1010
+            errorCode: 162
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 9
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groups:
+      - groupId: "random-string-220"
+        memberId: "random-string-641"
+        memberEpoch: 990
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 639
+    requireStable: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 712
+    groups:
+      - groupId: "random-string-750"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 65
+                committedOffset: 845
+                committedLeaderEpoch: 240
+                metadata: "random-string-576"
+                errorCode: 1010
+        errorCode: 162

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FOR_LEADER_EPOCH/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FOR_LEADER_EPOCH/2/baseline.yaml
@@ -1,0 +1,71 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FOR_LEADER_EPOCH"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FOR_LEADER_EPOCH"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 23
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 70
+                currentLeaderEpoch: 1003
+                leaderEpoch: 206
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 737
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - errorCode: 630
+                partition: 338
+                leaderEpoch: 631
+                endOffset: 230
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 23
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 70
+            currentLeaderEpoch: 1003
+            leaderEpoch: 206
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 737
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - errorCode: 630
+            partition: 338
+            leaderEpoch: 631
+            endOffset: 230

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FOR_LEADER_EPOCH/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FOR_LEADER_EPOCH/3/baseline.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FOR_LEADER_EPOCH"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FOR_LEADER_EPOCH"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 23
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 927
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 941
+                currentLeaderEpoch: 804
+                leaderEpoch: 620
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 935
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - errorCode: 688
+                partition: 332
+                leaderEpoch: 888
+                endOffset: 1005
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 23
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 927
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 941
+            currentLeaderEpoch: 804
+            leaderEpoch: 620
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 935
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - errorCode: 688
+            partition: 332
+            leaderEpoch: 888
+            endOffset: 1005

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FOR_LEADER_EPOCH/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_FOR_LEADER_EPOCH/4/baseline.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_FOR_LEADER_EPOCH"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_FOR_LEADER_EPOCH"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 23
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 590
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - partition: 806
+                currentLeaderEpoch: 31
+                leaderEpoch: 223
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 126
+        topics:
+          - topic: "my-topic"
+            partitions:
+              - errorCode: 449
+                partition: 611
+                leaderEpoch: 798
+                endOffset: 740
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 23
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 590
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - partition: 806
+            currentLeaderEpoch: 31
+            leaderEpoch: 223
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 126
+    topics:
+      - topic: "my-topic"
+        partitions:
+          - errorCode: 449
+            partition: 611
+            leaderEpoch: 798
+            endOffset: 740

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/10/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/10/baseline.yaml
@@ -1,0 +1,85 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 10
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 10
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 10
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-509"
+        acks: 1
+        timeoutMs: 492
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 942
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 64
+                errorCode: 396
+                baseOffset: 731
+                logAppendTimeMs: 618
+                logStartOffset: 422
+                recordErrors:
+                  - batchIndex: 674
+                    batchIndexErrorMessage: "random-string-258"
+                errorMessage: "random-string-267"
+        throttleTimeMs: 675
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 10
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-509"
+    acks: 1
+    timeoutMs: 492
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 942
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 64
+            errorCode: 396
+            baseOffset: 731
+            logAppendTimeMs: 618
+            logStartOffset: 422
+            recordErrors:
+              - batchIndex: 674
+                batchIndexErrorMessage: "random-string-258"
+            errorMessage: "random-string-267"
+    throttleTimeMs: 675

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/11/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/11/baseline.yaml
@@ -1,0 +1,85 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 11
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 11
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 11
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-450"
+        acks: 1
+        timeoutMs: 2
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 532
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 318
+                errorCode: 510
+                baseOffset: 338
+                logAppendTimeMs: 547
+                logStartOffset: 165
+                recordErrors:
+                  - batchIndex: 739
+                    batchIndexErrorMessage: "random-string-365"
+                errorMessage: "random-string-622"
+        throttleTimeMs: 894
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 11
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-450"
+    acks: 1
+    timeoutMs: 2
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 532
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 318
+            errorCode: 510
+            baseOffset: 338
+            logAppendTimeMs: 547
+            logStartOffset: 165
+            recordErrors:
+              - batchIndex: 739
+                batchIndexErrorMessage: "random-string-365"
+            errorMessage: "random-string-622"
+    throttleTimeMs: 894

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/baseline.yaml
@@ -1,0 +1,85 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 12
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 12
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-292"
+        acks: 1
+        timeoutMs: 141
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 134
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 969
+                errorCode: 51
+                baseOffset: 581
+                logAppendTimeMs: 693
+                logStartOffset: 269
+                recordErrors:
+                  - batchIndex: 164
+                    batchIndexErrorMessage: "random-string-410"
+                errorMessage: "random-string-667"
+        throttleTimeMs: 141
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 1
+    timeoutMs: 141
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 969
+            errorCode: 51
+            baseOffset: 581
+            logAppendTimeMs: 693
+            logStartOffset: 269
+            recordErrors:
+              - batchIndex: 164
+                batchIndexErrorMessage: "random-string-410"
+            errorMessage: "random-string-667"
+    throttleTimeMs: 141

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/3/baseline.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-999"
+        acks: 1
+        timeoutMs: 302
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 725
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 861
+                errorCode: 20
+                baseOffset: 1009
+                logAppendTimeMs: 717
+        throttleTimeMs: 804
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-999"
+    acks: 1
+    timeoutMs: 302
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 725
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 861
+            errorCode: 20
+            baseOffset: 1009
+            logAppendTimeMs: 717
+    throttleTimeMs: 804

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/4/baseline.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-292"
+        acks: 1
+        timeoutMs: 1003
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 923
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 173
+                errorCode: 542
+                baseOffset: 94
+                logAppendTimeMs: 462
+        throttleTimeMs: 473
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 1
+    timeoutMs: 1003
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 923
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 173
+            errorCode: 542
+            baseOffset: 94
+            logAppendTimeMs: 462
+    throttleTimeMs: 473

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/5/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-324"
+        acks: 1
+        timeoutMs: 978
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 794
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 769
+                errorCode: 1021
+                baseOffset: 969
+                logAppendTimeMs: 644
+                logStartOffset: 978
+        throttleTimeMs: 121
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-324"
+    acks: 1
+    timeoutMs: 978
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 794
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 769
+            errorCode: 1021
+            baseOffset: 969
+            logAppendTimeMs: 644
+            logStartOffset: 978
+    throttleTimeMs: 121

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/6/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 6
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-482"
+        acks: 1
+        timeoutMs: 289
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 120
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 655
+                errorCode: 658
+                baseOffset: 397
+                logAppendTimeMs: 200
+                logStartOffset: 407
+        throttleTimeMs: 117
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-482"
+    acks: 1
+    timeoutMs: 289
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 120
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 655
+            errorCode: 658
+            baseOffset: 397
+            logAppendTimeMs: 200
+            logStartOffset: 407
+    throttleTimeMs: 117

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/7/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/7/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 7
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 7
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 7
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-88"
+        acks: 1
+        timeoutMs: 855
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 169
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 967
+                errorCode: 260
+                baseOffset: 661
+                logAppendTimeMs: 100
+                logStartOffset: 145
+        throttleTimeMs: 73
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-88"
+    acks: 1
+    timeoutMs: 855
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 169
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 967
+            errorCode: 260
+            baseOffset: 661
+            logAppendTimeMs: 100
+            logStartOffset: 145
+    throttleTimeMs: 73

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/8/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/8/baseline.yaml
@@ -1,0 +1,85 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 8
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 8
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 8
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-197"
+        acks: 1
+        timeoutMs: 614
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 6
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 367
+                errorCode: 846
+                baseOffset: 238
+                logAppendTimeMs: 108
+                logStartOffset: 597
+                recordErrors:
+                  - batchIndex: 511
+                    batchIndexErrorMessage: "random-string-679"
+                errorMessage: "random-string-4"
+        throttleTimeMs: 597
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 8
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-197"
+    acks: 1
+    timeoutMs: 614
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 6
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 367
+            errorCode: 846
+            baseOffset: 238
+            logAppendTimeMs: 108
+            logStartOffset: 597
+            recordErrors:
+              - batchIndex: 511
+                batchIndexErrorMessage: "random-string-679"
+            errorMessage: "random-string-4"
+    throttleTimeMs: 597

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/9/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/9/baseline.yaml
@@ -1,0 +1,85 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 9
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 9
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 9
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-39"
+        acks: 1
+        timeoutMs: 314
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 399
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 737
+                errorCode: 184
+                baseOffset: 782
+                logAppendTimeMs: 506
+                logStartOffset: 265
+                recordErrors:
+                  - batchIndex: 519
+                    batchIndexErrorMessage: "random-string-236"
+                errorMessage: "random-string-728"
+        throttleTimeMs: 558
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-39"
+    acks: 1
+    timeoutMs: 314
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 399
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 737
+            errorCode: 184
+            baseOffset: 782
+            logAppendTimeMs: 506
+            logStartOffset: 265
+            recordErrors:
+              - batchIndex: 519
+                batchIndexErrorMessage: "random-string-236"
+            errorMessage: "random-string-728"
+    throttleTimeMs: 558

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_AUTHENTICATE/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_AUTHENTICATE/0/baseline.yaml
@@ -1,0 +1,55 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SASL_AUTHENTICATE"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SASL_AUTHENTICATE"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 36
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        authBytes: !!binary |-
+          LSagYRg=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 503
+        errorMessage: "random-string-429"
+        authBytes: !!binary |-
+          9egagDw=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 36
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    authBytes: !!binary |-
+      LSagYRg=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 503
+    errorMessage: "random-string-429"
+    authBytes: !!binary |-
+      9egagDw=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_AUTHENTICATE/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_AUTHENTICATE/1/baseline.yaml
@@ -1,0 +1,57 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SASL_AUTHENTICATE"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SASL_AUTHENTICATE"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 36
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        authBytes: !!binary |-
+          GFzoyLU=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 24
+        errorMessage: "random-string-543"
+        authBytes: !!binary |-
+          7anXRVE=
+        sessionLifetimeMs: 418
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 36
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    authBytes: !!binary |-
+      GFzoyLU=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 24
+    errorMessage: "random-string-543"
+    authBytes: !!binary |-
+      7anXRVE=
+    sessionLifetimeMs: 418

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_AUTHENTICATE/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_AUTHENTICATE/2/baseline.yaml
@@ -1,0 +1,57 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SASL_AUTHENTICATE"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SASL_AUTHENTICATE"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 36
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        authBytes: !!binary |-
+          1auuYUo=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 782
+        errorMessage: "random-string-701"
+        authBytes: !!binary |-
+          /kdhf5Y=
+        sessionLifetimeMs: 612
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 36
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    authBytes: !!binary |-
+      1auuYUo=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 782
+    errorMessage: "random-string-701"
+    authBytes: !!binary |-
+      /kdhf5Y=
+    sessionLifetimeMs: 612

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_HANDSHAKE/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_HANDSHAKE/0/baseline.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SASL_HANDSHAKE"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SASL_HANDSHAKE"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 17
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        mechanism: "random-string-942"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 525
+        mechanisms:
+          - "random-string-308"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 17
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    mechanism: "random-string-942"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 525
+    mechanisms:
+      - "random-string-308"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_HANDSHAKE/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SASL_HANDSHAKE/1/baseline.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SASL_HANDSHAKE"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SASL_HANDSHAKE"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 17
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        mechanism: "random-string-625"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 371
+        mechanisms:
+          - "random-string-578"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 17
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    mechanism: "random-string-625"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 371
+    mechanisms:
+      - "random-string-578"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/0/baseline.yaml
@@ -1,0 +1,63 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SYNC_GROUP"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SYNC_GROUP"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 14
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-275"
+        generationId: 696
+        memberId: "random-string-724"
+        assignments:
+          - memberId: "random-string-195"
+            assignment: !!binary |-
+              0SLf10U=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 812
+        assignment: !!binary |-
+          oZ+79i8=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 14
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-275"
+    generationId: 696
+    memberId: "random-string-724"
+    assignments:
+      - memberId: "random-string-195"
+        assignment: !!binary |-
+          0SLf10U=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 812
+    assignment: !!binary |-
+      oZ+79i8=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/1/baseline.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SYNC_GROUP"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SYNC_GROUP"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 14
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-629"
+        generationId: 586
+        memberId: "random-string-820"
+        assignments:
+          - memberId: "random-string-192"
+            assignment: !!binary |-
+              HYQNG9Y=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 611
+        errorCode: 319
+        assignment: !!binary |-
+          H/MOjxo=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 14
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-629"
+    generationId: 586
+    memberId: "random-string-820"
+    assignments:
+      - memberId: "random-string-192"
+        assignment: !!binary |-
+          HYQNG9Y=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 611
+    errorCode: 319
+    assignment: !!binary |-
+      H/MOjxo=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/2/baseline.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SYNC_GROUP"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SYNC_GROUP"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 14
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-50"
+        generationId: 280
+        memberId: "random-string-408"
+        assignments:
+          - memberId: "random-string-732"
+            assignment: !!binary |-
+              hpoqSB8=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 464
+        errorCode: 21
+        assignment: !!binary |-
+          O7Bzuoo=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 14
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-50"
+    generationId: 280
+    memberId: "random-string-408"
+    assignments:
+      - memberId: "random-string-732"
+        assignment: !!binary |-
+          hpoqSB8=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 464
+    errorCode: 21
+    assignment: !!binary |-
+      O7Bzuoo=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/3/baseline.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SYNC_GROUP"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SYNC_GROUP"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 14
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-397"
+        generationId: 620
+        memberId: "random-string-896"
+        groupInstanceId: "random-string-330"
+        assignments:
+          - memberId: "random-string-867"
+            assignment: !!binary |-
+              t9bWU+E=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 1004
+        errorCode: 512
+        assignment: !!binary |-
+          jhQd4Eo=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 14
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-397"
+    generationId: 620
+    memberId: "random-string-896"
+    groupInstanceId: "random-string-330"
+    assignments:
+      - memberId: "random-string-867"
+        assignment: !!binary |-
+          t9bWU+E=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 1004
+    errorCode: 512
+    assignment: !!binary |-
+      jhQd4Eo=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/4/baseline.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SYNC_GROUP"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SYNC_GROUP"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 14
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-985"
+        generationId: 747
+        memberId: "random-string-773"
+        groupInstanceId: "random-string-195"
+        assignments:
+          - memberId: "random-string-491"
+            assignment: !!binary |-
+              qrdChSE=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 739
+        errorCode: 868
+        assignment: !!binary |-
+          nZHKxws=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 14
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-985"
+    generationId: 747
+    memberId: "random-string-773"
+    groupInstanceId: "random-string-195"
+    assignments:
+      - memberId: "random-string-491"
+        assignment: !!binary |-
+          qrdChSE=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 739
+    errorCode: 868
+    assignment: !!binary |-
+      nZHKxws=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/SYNC_GROUP/5/baseline.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "SYNC_GROUP"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "SYNC_GROUP"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 14
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "random-string-533"
+        generationId: 638
+        memberId: "random-string-998"
+        groupInstanceId: "random-string-40"
+        protocolType: "random-string-469"
+        protocolName: "random-string-810"
+        assignments:
+          - memberId: "random-string-738"
+            assignment: !!binary |-
+              dvOjL2A=
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 1006
+        errorCode: 685
+        protocolType: "random-string-801"
+        protocolName: "random-string-374"
+        assignment: !!binary |-
+          V3FtJR0=
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 14
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "random-string-533"
+    generationId: 638
+    memberId: "random-string-998"
+    groupInstanceId: "random-string-40"
+    protocolType: "random-string-469"
+    protocolName: "random-string-810"
+    assignments:
+      - memberId: "random-string-738"
+        assignment: !!binary |-
+          dvOjL2A=
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 1006
+    errorCode: 685
+    protocolType: "random-string-801"
+    protocolName: "random-string-374"
+    assignment: !!binary |-
+      V3FtJR0=

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/0/baseline.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "TXN_OFFSET_COMMIT"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "TXN_OFFSET_COMMIT"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 28
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-4"
+        groupId: "random-string-895"
+        producerId: 525
+        producerEpoch: 828
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 815
+                committedOffset: 978
+                committedMetadata: "random-string-946"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 385
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 464
+                errorCode: 558
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 28
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-4"
+    groupId: "random-string-895"
+    producerId: 525
+    producerEpoch: 828
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 815
+            committedOffset: 978
+            committedMetadata: "random-string-946"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 385
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 464
+            errorCode: 558

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/1/baseline.yaml
@@ -1,0 +1,75 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "TXN_OFFSET_COMMIT"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "TXN_OFFSET_COMMIT"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 28
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-272"
+        groupId: "random-string-264"
+        producerId: 181
+        producerEpoch: 687
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 493
+                committedOffset: 803
+                committedMetadata: "random-string-149"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 308
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 510
+                errorCode: 276
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 28
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-272"
+    groupId: "random-string-264"
+    producerId: 181
+    producerEpoch: 687
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 493
+            committedOffset: 803
+            committedMetadata: "random-string-149"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 308
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 510
+            errorCode: 276

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/2/baseline.yaml
@@ -1,0 +1,77 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "TXN_OFFSET_COMMIT"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "TXN_OFFSET_COMMIT"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 28
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-658"
+        groupId: "random-string-274"
+        producerId: 955
+        producerEpoch: 469
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 713
+                committedOffset: 718
+                committedLeaderEpoch: 535
+                committedMetadata: "random-string-567"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 640
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 224
+                errorCode: 668
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 28
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-658"
+    groupId: "random-string-274"
+    producerId: 955
+    producerEpoch: 469
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 713
+            committedOffset: 718
+            committedLeaderEpoch: 535
+            committedMetadata: "random-string-567"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 640
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 224
+            errorCode: 668

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/3/baseline.yaml
@@ -1,0 +1,83 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "TXN_OFFSET_COMMIT"
+  apiVersion: 3
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "TXN_OFFSET_COMMIT"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 28
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-442"
+        groupId: "random-string-911"
+        producerId: 667
+        producerEpoch: 91
+        generationId: 981
+        memberId: "random-string-168"
+        groupInstanceId: "random-string-114"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 1006
+                committedOffset: 773
+                committedLeaderEpoch: 231
+                committedMetadata: "random-string-610"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 117
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 909
+                errorCode: 985
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 28
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-442"
+    groupId: "random-string-911"
+    producerId: 667
+    producerEpoch: 91
+    generationId: 981
+    memberId: "random-string-168"
+    groupInstanceId: "random-string-114"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 1006
+            committedOffset: 773
+            committedLeaderEpoch: 231
+            committedMetadata: "random-string-610"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 117
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 909
+            errorCode: 985

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/4/baseline.yaml
@@ -1,0 +1,83 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "TXN_OFFSET_COMMIT"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "TXN_OFFSET_COMMIT"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 28
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-171"
+        groupId: "random-string-748"
+        producerId: 913
+        producerEpoch: 776
+        generationId: 556
+        memberId: "random-string-1003"
+        groupInstanceId: "random-string-746"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 841
+                committedOffset: 41
+                committedLeaderEpoch: 688
+                committedMetadata: "random-string-936"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 686
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 658
+                errorCode: 891
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 28
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-171"
+    groupId: "random-string-748"
+    producerId: 913
+    producerEpoch: 776
+    generationId: 556
+    memberId: "random-string-1003"
+    groupInstanceId: "random-string-746"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 841
+            committedOffset: 41
+            committedLeaderEpoch: 688
+            committedMetadata: "random-string-936"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 686
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 658
+            errorCode: 891

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/TXN_OFFSET_COMMIT/5/baseline.yaml
@@ -1,0 +1,83 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "TXN_OFFSET_COMMIT"
+  apiVersion: 5
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "TXN_OFFSET_COMMIT"
+      expectedRequestVersion: 5
+      expectedRequestHeader:
+        requestApiKey: 28
+        requestApiVersion: 5
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-186"
+        groupId: "random-string-717"
+        producerId: 0
+        producerEpoch: 104
+        generationId: 988
+        memberId: "random-string-854"
+        groupInstanceId: "random-string-46"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 537
+                committedOffset: 954
+                committedLeaderEpoch: 409
+                committedMetadata: "random-string-353"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 709
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 241
+                errorCode: 612
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 28
+    requestApiVersion: 5
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-186"
+    groupId: "random-string-717"
+    producerId: 0
+    producerEpoch: 104
+    generationId: 988
+    memberId: "random-string-854"
+    groupInstanceId: "random-string-46"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 537
+            committedOffset: 954
+            committedLeaderEpoch: 409
+            committedMetadata: "random-string-353"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 709
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 241
+            errorCode: 612


### PR DESCRIPTION
We need to combine authorized operations bitsets emitted in the Metadata Response, so that we only advertise operations allowed by both upstream AND the Filter.

Testing the intersection logic in the bitset doesn't quite fit with the current Integration Testing approach where we want to compare an unproxied and proxied cluster with matching ACL-type policies to check they agree.

So I've introduced a unit testing approach using a mock upstream, mocking out the relevant parts of the FilterContext. Each scenario file describe the RPC to send, any mock responses upstream, and the final response expectation.