### PR TITLE
Fix describe producers enforcement edge case

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_PRODUCERS/0/no-topics-in-upstream-response.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_PRODUCERS/0/no-topics-in-upstream-response.yaml
@@ -1,0 +1,86 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DESCRIBE_PRODUCERS"
+  apiVersion: 0
+  scenario: |
+    covers an unexpected edge case where the upstream responds with empty topics
+    we expect denied topics to be augmented into the response
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "DESCRIBE_PRODUCERS"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 61
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "client-id"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 244
+          - name: "my-topic2"
+            partitionIndexes:
+              - 244
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 55
+        # empty topics
+        topics: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+      - subject: "alice"
+        resourceName: "my-topic2"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: { }
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 61
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "client-id"
+  request:
+    topics:
+      - name: "unauthorized"
+        partitionIndexes:
+          - 244
+      - name: "my-topic"
+        partitionIndexes:
+          - 244
+      - name: "unauthorized2"
+        partitionIndexes:
+          - 244
+      - name: "my-topic2"
+        partitionIndexes:
+          - 244
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 55
+    topics:
+      - name: "unauthorized"
+        partitions:
+          - partitionIndex: 244
+            errorCode: 29
+            errorMessage: "Topic authorization failed."
+            activeProducers: [ ]
+      - name: "unauthorized2"
+        partitions:
+          - partitionIndex: 244
+            errorCode: 29
+            errorMessage: "Topic authorization failed."
+            activeProducers: [ ]

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_PRODUCERS/0/not-all-topics-in-upstream-response.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_PRODUCERS/0/not-all-topics-in-upstream-response.yaml
@@ -1,0 +1,110 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DESCRIBE_PRODUCERS"
+  apiVersion: 0
+  scenario: |
+    covers an unexpected edge case where the upstream responds with less topics than are requested
+    we expect denied topics to be augmented into the response
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "DESCRIBE_PRODUCERS"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 61
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "client-id"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            partitionIndexes:
+              - 244
+          - name: "my-topic2"
+            partitionIndexes:
+              - 244
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 55
+        topics:
+          # only my-topic is present, no response for my-topic2
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 297
+                errorCode: 266
+                errorMessage: "random-string-138"
+                activeProducers:
+                  - producerId: 965
+                    producerEpoch: 576
+                    lastSequence: 998
+                    lastTimestamp: 111
+                    coordinatorEpoch: 602
+                    currentTxnStartOffset: 172
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+      - subject: "alice"
+        resourceName: "my-topic2"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: { }
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 61
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "client-id"
+  request:
+    topics:
+      - name: "unauthorized"
+        partitionIndexes:
+          - 244
+      - name: "my-topic"
+        partitionIndexes:
+          - 244
+      - name: "unauthorized2"
+        partitionIndexes:
+          - 244
+      - name: "my-topic2"
+        partitionIndexes:
+          - 244
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 55
+    topics:
+      - name: "unauthorized"
+        partitions:
+          - partitionIndex: 244
+            errorCode: 29
+            errorMessage: "Topic authorization failed."
+            activeProducers: [ ]
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 297
+            errorCode: 266
+            errorMessage: "random-string-138"
+            activeProducers:
+              - producerId: 965
+                producerEpoch: 576
+                lastSequence: 998
+                lastTimestamp: 111
+                coordinatorEpoch: 602
+                currentTxnStartOffset: 172
+      - name: "unauthorized2"
+        partitions:
+          - partitionIndex: 244
+            errorCode: 29
+            errorMessage: "Topic authorization failed."
+            activeProducers: [ ]


### PR DESCRIPTION
Inserting by index is risky if the upstream responded with an unexpected number of topics for some reason. Instead we do a best-effort sort of the topics after adding in the error cases.