### PR TITLE
Require describe txn find coordinators testing

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ScenarioDefinition.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ScenarioDefinition.java
@@ -71,10 +71,15 @@ public record ScenarioDefinition(Metadata metadata, Given given, When when, Then
                        @Nullable Errors expectedErrorResponse,
                        @Nullable Boolean hasResponse,
                        @Nullable Boolean expectRequestDropped,
-                       @Nullable RequestError expectedRequestError) {
+                       @Nullable RequestError expectedRequestError,
+                       @Nullable Boolean expectAuthorizationOutcomeLog) {
 
         boolean getHasResponse() {
             return hasResponse == null || hasResponse;
+        }
+
+        boolean isExpectAuthorizationOutcomeLog() {
+            return expectAuthorizationOutcomeLog == null || expectAuthorizationOutcomeLog;
         }
 
         boolean isExpectRequestDropped() {

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ALTER_CONFIGS/0/other-resources.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ALTER_CONFIGS/0/other-resources.yaml
@@ -58,6 +58,7 @@ when:
             value: "random-string-216"
     validateOnly: true
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ALTER_CONFIGS/1/other-resources.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ALTER_CONFIGS/1/other-resources.yaml
@@ -58,6 +58,7 @@ when:
             value: "random-string-11"
     validateOnly: true
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ALTER_CONFIGS/2/other-resources.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/ALTER_CONFIGS/2/other-resources.yaml
@@ -58,6 +58,7 @@ when:
             value: "random-string-250"
     validateOnly: true
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_RECORDS/2/empty-topics-forwarded.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_RECORDS/2/empty-topics-forwarded.yaml
@@ -44,6 +44,7 @@ when:
     topics: []
     timeoutMs: 812
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_CONFIGS/1/other-resources.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_CONFIGS/1/other-resources.yaml
@@ -66,6 +66,7 @@ when:
           - "random-string-467"
     includeSynonyms: true
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_CONFIGS/2/other-resources.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_CONFIGS/2/other-resources.yaml
@@ -66,6 +66,7 @@ when:
           - "random-string-682"
     includeSynonyms: true
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_CONFIGS/3/other-resources.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_CONFIGS/3/other-resources.yaml
@@ -70,6 +70,7 @@ when:
     includeSynonyms: false
     includeDocumentation: true
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_CONFIGS/4/other-resources.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_CONFIGS/4/other-resources.yaml
@@ -70,6 +70,7 @@ when:
     includeSynonyms: false
     includeDocumentation: true
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_PRODUCERS/0/empty-topics.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DESCRIBE_PRODUCERS/0/empty-topics.yaml
@@ -42,6 +42,7 @@ when:
   request:
     topics: []
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/0/baseline.yaml
@@ -44,6 +44,7 @@ when:
   request:
     key: "random-string-715"
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/1/baseline.yaml
@@ -48,6 +48,7 @@ when:
     key: "random-string-435"
     keyType: 34
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/2/baseline.yaml
@@ -48,6 +48,7 @@ when:
     key: "random-string-600"
     keyType: 17
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/3/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/3/baseline.yaml
@@ -48,6 +48,7 @@ when:
     key: "random-string-480"
     keyType: 57
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/4/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/4/baseline.yaml
@@ -52,6 +52,7 @@ when:
     coordinatorKeys:
       - "random-string-977"
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/5/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/5/baseline.yaml
@@ -52,6 +52,7 @@ when:
     coordinatorKeys:
       - "random-string-934"
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/6/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FIND_COORDINATOR/6/baseline.yaml
@@ -52,6 +52,7 @@ when:
     coordinatorKeys:
       - "random-string-191"
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INCREMENTAL_ALTER_CONFIGS/0/other-resources.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INCREMENTAL_ALTER_CONFIGS/0/other-resources.yaml
@@ -60,6 +60,7 @@ when:
             value: "random-string-788"
     validateOnly: false
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INCREMENTAL_ALTER_CONFIGS/1/other-resources.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/INCREMENTAL_ALTER_CONFIGS/1/other-resources.yaml
@@ -60,6 +60,7 @@ when:
             value: "random-string-752"
     validateOnly: false
 then:
+  expectAuthorizationOutcomeLog: false
   expectedResponseHeader:
     correlationId: 1
   expectedResponse:

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/out-of-band-metadata-request-errors.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/out-of-band-metadata-request-errors.yaml
@@ -59,6 +59,7 @@ when:
     allowAutoTopicCreation: true
     includeTopicAuthorizedOperations: false
 then:
+  expectAuthorizationOutcomeLog: false
   expectedRequestError:
     withCauseType: io.kroxylicious.filter.authorization.AuthorizationException
     withCauseMessage: "Internal metadata request failed with UNKNOWN_SERVER_ERROR"


### PR DESCRIPTION
* Adds tests for supported resource behaviours on the Filter
* Fixes up a problem this exposed with the logging asserts. When I added the new unit tests, the logging asserts for all the other scenarios broke because there were some authorizations logged for the anonymous subject, so they contained `[]`. 