### PR TITLE
test(runtime): add IT for cross-route InternalRequestFrame contamination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Format `<github issue/pr number>: <short description>`.
 ## SNAPSHOT
 
 * [#3783](https://github.com/kroxylicious/kroxylicious/issues/3783): fix(config): remove deprecated `shutdownQuietPeriodSeconds` field from `NettySettings`.
+* [#4156](https://github.com/kroxylicious/kroxylicious/issues/4156): feat(runtime): **Preview** — per-route filter chains. 
+  Routes in `routerDefinitions` can now declare their own `filters` list; 
+  these filters apply only to traffic on that route, executing after virtual-cluster-level filters. 
+  Route filter definition changes are detected during hot reload.
 
 ### Changes, deprecations and removals
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterRouteFilterApiIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/FilterRouteFilterApiIT.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ListGroupsResponseData;
+import org.apache.kafka.common.message.ListTransactionsRequestData;
+import org.apache.kafka.common.message.ListTransactionsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
+
+import io.kroxylicious.filter.simpletransform.FetchResponseTransformation;
+import io.kroxylicious.filter.simpletransform.ProduceRequestTransformation;
+import io.kroxylicious.it.testplugins.ForwardingStyle;
+import io.kroxylicious.it.testplugins.RejectingCreateTopicFilter;
+import io.kroxylicious.it.testplugins.RejectingCreateTopicFilterFactory;
+import io.kroxylicious.it.testplugins.RequestCountingFilter;
+import io.kroxylicious.it.testplugins.RequestCountingFilterFactory;
+import io.kroxylicious.it.testplugins.RequestResponseMarkingFilter;
+import io.kroxylicious.it.testplugins.RequestResponseMarkingFilterFactory;
+import io.kroxylicious.it.testplugins.router.PassThroughRouterFactory;
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.internal.config.Feature;
+import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.testing.integration.Request;
+import io.kroxylicious.testing.integration.Response;
+import io.kroxylicious.testing.integration.ResponsePayload;
+import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.it.UnknownTaggedFields.unknownTaggedFieldsToStrings;
+import static io.kroxylicious.it.testplugins.RequestResponseMarkingFilter.FILTER_NAME_TAG;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.baseConfigurationBuilder;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG;
+import static org.apache.kafka.common.protocol.ApiKeys.API_VERSIONS;
+import static org.apache.kafka.common.protocol.ApiKeys.FETCH;
+import static org.apache.kafka.common.protocol.ApiKeys.LIST_GROUPS;
+import static org.apache.kafka.common.protocol.ApiKeys.LIST_TRANSACTIONS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Verifies that filter APIs work correctly when filters are configured on routes rather
+ * than on the virtual cluster.  Each test places its filter in the route's filter chain
+ * rather than in the VC's default filter list, confirming that the route-level placement
+ * does not break any filter contract.
+ */
+@ExtendWith(KafkaClusterExtension.class)
+@ExtendWith(NettyLeakDetectorExtension.class)
+class FilterRouteFilterApiIT {
+
+    private static final Features ROUTING_ENABLED = Features.builder().enable(Feature.ROUTING).build();
+    private static final String ROUTE_NAME = "default-route";
+    private static final String ROUTER_NAME = "pass-through";
+    private static final String CLUSTER_NAME = "backing";
+    private static final String PLAINTEXT = "Hello, world!";
+
+    private ConfigurationBuilder routedConfigWithRouteFilter(String bootstrapServers, NamedFilterDefinition... filterDefs) {
+        var clusterDef = new ClusterDefinition(CLUSTER_NAME, bootstrapServers, null);
+        var filterNames = Arrays.stream(filterDefs).map(NamedFilterDefinition::name).toList();
+        var route = new RouteDefinition(ROUTE_NAME, 0, filterNames, new RouteTarget(CLUSTER_NAME, null));
+        var routerConfig = new PassThroughRouterFactory.Config(ROUTE_NAME);
+        var routerDef = new RouterDefinition(ROUTER_NAME, PassThroughRouterFactory.class.getName(), routerConfig, List.of(route));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        var builder = baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+        for (var fd : filterDefs) {
+            builder.addToFilterDefinitions(fd);
+        }
+        return builder;
+    }
+
+    @Test
+    void requestFilterCanModifyProduceRequestOnRoute(KafkaCluster cluster, Topic topic) throws Exception {
+        var bytes = PLAINTEXT.getBytes(StandardCharsets.UTF_8);
+        var expected = AbstractFilterIT.encode(topic.name(), ByteBuffer.wrap(bytes)).array();
+
+        // Given
+        var filterDef = new NamedFilterDefinitionBuilder(ProduceRequestTransformation.class.getName(), ProduceRequestTransformation.class.getName())
+                .withConfig("transformation", TestEncoderFactory.class.getName())
+                .build();
+        var config = routedConfigWithRouteFilter(cluster.getBootstrapServers(), filterDef);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "test", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer(Serdes.String(), Serdes.ByteArray(),
+                        Map.of(GROUP_ID_CONFIG, "encode-group", AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            // When
+            producer.send(new ProducerRecord<>(topic.name(), "key", PLAINTEXT)).get();
+            consumer.subscribe(Set.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(10));
+
+            // Then
+            assertThat(records.records(topic.name()))
+                    .hasSize(1)
+                    .map(ConsumerRecord::value)
+                    .containsExactly(expected);
+        }
+    }
+
+    @Test
+    void responseFilterCanModifyFetchResponseOnRoute(KafkaCluster cluster, Topic topic) throws Exception {
+        var bytes = PLAINTEXT.getBytes(StandardCharsets.UTF_8);
+        var encoded = AbstractFilterIT.encode(topic.name(), ByteBuffer.wrap(bytes)).array();
+
+        // Given
+        var filterDef = new NamedFilterDefinitionBuilder("fetch-decoder", FetchResponseTransformation.class.getName())
+                .withConfig("transformation", TestDecoderFactory.class.getName())
+                .build();
+        var config = routedConfigWithRouteFilter(cluster.getBootstrapServers(), filterDef);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer(Serdes.String(), Serdes.ByteArray(),
+                        Map.of(CLIENT_ID_CONFIG, "test", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer(Map.of(GROUP_ID_CONFIG, "decode-group", AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            // When
+            producer.send(new ProducerRecord<>(topic.name(), "key", encoded)).get();
+            consumer.subscribe(Set.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(10));
+
+            // Then
+            assertThat(records.records(topic.name()))
+                    .hasSize(1)
+                    .map(ConsumerRecord::value)
+                    .containsExactly(PLAINTEXT);
+        }
+    }
+
+    @Test
+    void requestFilterCanShortCircuitResponseOnRoute(KafkaCluster cluster) {
+        // Given
+        var filterDef = new NamedFilterDefinitionBuilder(RejectingCreateTopicFilterFactory.class.getName(), RejectingCreateTopicFilterFactory.class.getName())
+                .build();
+        var config = routedConfigWithRouteFilter(cluster.getBootstrapServers(), filterDef);
+        var topicName = "should-not-be-created";
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var admin = tester.admin()) {
+
+            // When / Then
+            assertThatExceptionOfType(ExecutionException.class)
+                    .isThrownBy(() -> admin.createTopics(List.of(new NewTopic(topicName, 1, (short) 1))).all().get())
+                    .withCauseInstanceOf(InvalidTopicException.class)
+                    .havingCause()
+                    .withMessage(RejectingCreateTopicFilter.ERROR_MESSAGE);
+        }
+    }
+
+    @Test
+    void routeFilterCanSendOutOfBandRequestToBroker() {
+        var filterName = "marking-filter";
+
+        // Given
+        var filterDef = new NamedFilterDefinitionBuilder(filterName, RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(LIST_TRANSACTIONS),
+                        "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.REQUEST,
+                                RequestResponseMarkingFilterFactory.Direction.RESPONSE),
+                        "name", filterName,
+                        "forwardingStyle", ForwardingStyle.ASYNCHRONOUS_REQUEST_TO_BROKER)
+                .build();
+
+        try (var tester = KroxyliciousTesters.mockKafkaKroxyliciousTester(
+                mockBootstrap -> routedConfigWithRouteFilter(mockBootstrap, filterDef), ROUTING_ENABLED);
+                var client = tester.simpleTestClient()) {
+
+            ApiVersionsResponseData apiVersions = new ApiVersionsResponseData();
+            apiVersions.apiKeys().add(new ApiVersionsResponseData.ApiVersion()
+                    .setApiKey(FETCH.id).setMaxVersion(FETCH.latestVersion()).setMinVersion(FETCH.oldestVersion()));
+            tester.addMockResponseForApiKey(new ResponsePayload(API_VERSIONS, API_VERSIONS.latestVersion(), apiVersions));
+            tester.addMockResponseForApiKey(new ResponsePayload(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), new ListTransactionsResponseData()));
+            tester.addMockResponseForApiKey(new ResponsePayload(LIST_GROUPS, LIST_GROUPS.latestVersion(), new ListGroupsResponseData()));
+
+            // When
+            Response response = client.getSync(new Request(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData()));
+
+            // Then
+            var requestAtBroker = tester.getOnlyRequestForApiKey(LIST_TRANSACTIONS).message();
+            var responseAtClient = response.payload().message();
+            assertThat(unknownTaggedFieldsToStrings(requestAtBroker, FILTER_NAME_TAG))
+                    .containsExactly(RequestResponseMarkingFilter.class.getSimpleName() + "-" + filterName + "-request");
+            assertThat(unknownTaggedFieldsToStrings(responseAtClient, FILTER_NAME_TAG))
+                    .containsExactly(RequestResponseMarkingFilter.class.getSimpleName() + "-" + filterName + "-response");
+        }
+    }
+
+    @Test
+    void routeFilterReceivesRequestAndResponseForSameExchange(KafkaCluster cluster, Topic topic) throws Exception {
+        var filterName = "req-resp-marker";
+
+        // Given
+        var filterDef = new NamedFilterDefinitionBuilder(filterName, RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(ApiKeys.PRODUCE),
+                        "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.REQUEST,
+                                RequestResponseMarkingFilterFactory.Direction.RESPONSE),
+                        "name", filterName,
+                        "forwardingStyle", ForwardingStyle.SYNCHRONOUS)
+                .build();
+        var config = routedConfigWithRouteFilter(cluster.getBootstrapServers(), filterDef);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "test", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000))) {
+
+            // When
+            producer.send(new ProducerRecord<>(topic.name(), "key", "value")).get();
+
+            // Then: no exception means both request and response paths completed correctly through the route filter
+        }
+    }
+
+    @Test
+    void apiVersionsRequestUsedForVersionNegotiationPassesThroughRouteFilter(KafkaCluster cluster, Topic topic) throws Exception {
+        // Given
+        RequestCountingFilter.reset("api-versions-test");
+        var filterDef = new NamedFilterDefinitionBuilder("counter", RequestCountingFilterFactory.class.getName())
+                .withConfig("counterId", "api-versions-test")
+                .build();
+        var config = routedConfigWithRouteFilter(cluster.getBootstrapServers(), filterDef);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer()) {
+
+            // When
+            producer.send(new ProducerRecord<>(topic.name(), "key", "value")).get();
+        }
+
+        // Then: the filter was invoked for traffic through the route (API_VERSIONS is used during handshake)
+        assertThat(RequestCountingFilter.countFor("api-versions-test", ApiKeys.API_VERSIONS)).isGreaterThanOrEqualTo(1);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ListGroupsResponseData;
+import org.apache.kafka.common.message.ListTransactionsRequestData;
+import org.apache.kafka.common.message.ListTransactionsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
+
+import io.kroxylicious.it.testplugins.ForwardingStyle;
+import io.kroxylicious.it.testplugins.RequestCountingFilter;
+import io.kroxylicious.it.testplugins.RequestCountingFilterFactory;
+import io.kroxylicious.it.testplugins.RequestResponseMarkingFilter;
+import io.kroxylicious.it.testplugins.RequestResponseMarkingFilterFactory;
+import io.kroxylicious.it.testplugins.router.DynamicProduceRouterFactory;
+import io.kroxylicious.it.testplugins.router.PassThroughRouterFactory;
+import io.kroxylicious.it.testplugins.router.SplitStaticRouterFactory;
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.internal.config.Feature;
+import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.testing.integration.Request;
+import io.kroxylicious.testing.integration.Response;
+import io.kroxylicious.testing.integration.ResponsePayload;
+import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.it.UnknownTaggedFields.unknownTaggedFieldsToStrings;
+import static io.kroxylicious.it.testplugins.RequestResponseMarkingFilter.FILTER_NAME_TAG;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.baseConfigurationBuilder;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG;
+import static org.apache.kafka.common.protocol.ApiKeys.API_VERSIONS;
+import static org.apache.kafka.common.protocol.ApiKeys.FETCH;
+import static org.apache.kafka.common.protocol.ApiKeys.LIST_GROUPS;
+import static org.apache.kafka.common.protocol.ApiKeys.LIST_TRANSACTIONS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests that demonstrate correctness issues identified in the per-route filter
+ * chain implementation.  Each test targets a specific bug and is expected to fail until
+ * the corresponding issue is fixed.
+ *
+ * <p>C1: Router-internal frames pass through route filter handlers.
+ * <p>C2: {@code correlationIdToRoute} entries are never removed for router-internal requests.
+ * <p>C3: {@code sendRequest()} in a route filter sends to an arbitrary backend when multiple
+ *         routes are active.
+ * <p>C4: Test name / behaviour mismatch in RouterDispatchHandlerTest masks a regression where
+ *         forwarding failures leave the pending future stuck rather than completing exceptionally.
+ */
+@ExtendWith(KafkaClusterExtension.class)
+@ExtendWith(NettyLeakDetectorExtension.class)
+class RouteFilterCorrectnessIT {
+
+    private static final Features ROUTING_ENABLED = Features.builder().enable(Feature.ROUTING).build();
+    private static final String ROUTER_NAME = "router";
+    private static final String CLUSTER_NAME = "backing";
+    private static final String ROUTE_A = "route-a";
+
+    // ---------------------------------------------------------------------------
+    // C1: Router-internal frames pass through route filter handlers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * When a router uses dynamic routing (e.g. {@link DynamicProduceRouterFactory}), it
+     * forwards the original request to the backend by calling
+     * {@code RouterContext.sendRequest()}, which creates a plain {@code DecodedRequestFrame}
+     * and fires it back through the inbound pipeline via {@code ctx.fireChannelRead()}.
+     * Because route filter handlers sit after {@code RouterDispatchHandler} in the pipeline,
+     * these router-internal frames pass through them.  A route filter that intercepts PRODUCE
+     * will therefore be invoked once for the client's request <em>and</em> once for the
+     * router's re-forwarded copy — a count of 2 instead of the expected 1.
+     *
+     * <p>This test fails until C1 is fixed.
+     */
+    @Test
+    void routeFiltersAreErroneouslyInvokedOnRouterInternalFrames(KafkaCluster cluster, Topic topic) throws Exception {
+        String counterId = "c1-" + topic.name();
+        RequestCountingFilter.reset(counterId);
+
+        // Given
+        var filterDef = new NamedFilterDefinitionBuilder("counter", RequestCountingFilterFactory.class.getName())
+                .withConfig("counterId", counterId)
+                .build();
+        var clusterDef = new ClusterDefinition(CLUSTER_NAME, cluster.getBootstrapServers(), null);
+        var route = new RouteDefinition(ROUTE_A, 0, List.of("counter"), new RouteTarget(CLUSTER_NAME, null));
+        var routerDef = new RouterDefinition(ROUTER_NAME, DynamicProduceRouterFactory.class.getName(),
+                new DynamicProduceRouterFactory.Config(ROUTE_A), List.of(route));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        var config = baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToFilterDefinitions(filterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer(Map.of(DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000))) {
+
+            // When
+            producer.send(new ProducerRecord<>(topic.name(), "key", "value")).get();
+        }
+
+        // Then: the route filter should have been invoked exactly once, for the client's PRODUCE.
+        // C1 bug: RouterDispatchHandler also fires the re-forwarded PRODUCE through the pipeline,
+        // so the count is 2.
+        assertThat(RequestCountingFilter.countFor(counterId, ApiKeys.PRODUCE))
+                .as("route filter should see only client-originated PRODUCE requests, not router-internal copies")
+                .isEqualTo(1);
+    }
+
+    // ---------------------------------------------------------------------------
+    // C2: correlationIdToRoute entries never removed for router-internal requests
+    // ---------------------------------------------------------------------------
+
+    /**
+     * {@code RoutingTerminalHandler} records a {@code correlationId → routeName} mapping for
+     * every inbound frame that expects a response.  When a router-internal frame goes through
+     * the terminal handler (as a consequence of C1), its router-range correlation ID is
+     * recorded.  The response is then consumed by {@code RouterDispatchHandler.write()} without
+     * calling {@code ctx.write()}, so {@code RoutingTerminalHandler.write()} is never triggered
+     * and the entry is never removed.
+     *
+     * <p>This leak is bounded (router correlation IDs cycle through a fixed range) and does
+     * not currently cause observable routing failures with a single route.  A targeted unit test
+     * against {@code RoutingTerminalHandler} is the appropriate level at which to assert the
+     * map invariant directly.  This test exercises the same code path at the integration level
+     * and verifies that routing remains correct after many dynamic-produce operations.
+     */
+    @Test
+    void routingRemainsStableAfterManyDynamicOperations(KafkaCluster cluster, Topic topic) throws Exception {
+        // Given
+        var clusterDef = new ClusterDefinition(CLUSTER_NAME, cluster.getBootstrapServers(), null);
+        var route = new RouteDefinition(ROUTE_A, 0, List.of(), new RouteTarget(CLUSTER_NAME, null));
+        var routerDef = new RouterDefinition(ROUTER_NAME, DynamicProduceRouterFactory.class.getName(),
+                new DynamicProduceRouterFactory.Config(ROUTE_A), List.of(route));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        var config = baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer(Map.of(DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer(Map.of(GROUP_ID_CONFIG, "c2-stability", AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            // When: many dynamic produce cycles (each triggers a router-internal re-forward that leaks a map entry)
+            for (int i = 0; i < 50; i++) {
+                producer.send(new ProducerRecord<>(topic.name(), "key", "value-" + i)).get();
+            }
+
+            consumer.subscribe(Set.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(30));
+
+            // Then: routing continues to deliver all records correctly despite the growing correlationIdToRoute map
+            assertThat(records).hasSize(50);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // C3: sendRequest() from a route filter goes to an arbitrary backend
+    // ---------------------------------------------------------------------------
+
+    /**
+     * When a route filter calls {@code FilterContext.sendRequest()}, the resulting
+     * {@code InternalRequestFrame} reaches {@code RoutingTerminalHandler} with a null route
+     * name.  The terminal handler delegates to
+     * {@code ClientConnectionStateMachine.onClientFilterChainComplete()}, which picks a backend
+     * connection via {@code serverConnections.values().iterator().next()}.  With a single active
+     * route this always returns the correct connection.  With two or more routes whose backends
+     * differ, the choice is non-deterministic.
+     *
+     * <p>This test uses a single cluster and a single route, so {@code sendRequest()} works
+     * correctly by accident.  Demonstrating the actual bug requires two distinct Kafka clusters
+     * (one per route) so that sending to the wrong connection produces a different — observable
+     * — response.  See the disabled companion test below.
+     */
+    @Test
+    void routeFilterSendRequestWorksWithSingleRoute() {
+        var filterName = "c3-marker";
+
+        // Given
+        var filterDef = new NamedFilterDefinitionBuilder(filterName, RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(LIST_TRANSACTIONS),
+                        "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.REQUEST),
+                        "name", filterName,
+                        "forwardingStyle", ForwardingStyle.ASYNCHRONOUS_REQUEST_TO_BROKER)
+                .build();
+
+        try (var tester = KroxyliciousTesters.mockKafkaKroxyliciousTester(
+                mockBootstrap -> singleRouteConfig(mockBootstrap, filterDef), ROUTING_ENABLED);
+                var client = tester.simpleTestClient()) {
+
+            ApiVersionsResponseData apiVersions = new ApiVersionsResponseData();
+            apiVersions.apiKeys().add(new ApiVersionsResponseData.ApiVersion()
+                    .setApiKey(FETCH.id).setMaxVersion(FETCH.latestVersion()).setMinVersion(FETCH.oldestVersion()));
+            tester.addMockResponseForApiKey(new ResponsePayload(API_VERSIONS, API_VERSIONS.latestVersion(), apiVersions));
+            tester.addMockResponseForApiKey(new ResponsePayload(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), new ListTransactionsResponseData()));
+            tester.addMockResponseForApiKey(new ResponsePayload(LIST_GROUPS, LIST_GROUPS.latestVersion(), new ListGroupsResponseData()));
+
+            // When
+            Response response = client.getSync(new Request(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData()));
+
+            // Then: sendRequest() reached the correct (only) backend and the filter marked the request
+            var requestAtBroker = tester.getOnlyRequestForApiKey(LIST_TRANSACTIONS).message();
+            assertThat(unknownTaggedFieldsToStrings(requestAtBroker, FILTER_NAME_TAG))
+                    .as("filter must have marked the request, proving sendRequest() reached the mock backend")
+                    .containsExactly(RequestResponseMarkingFilter.class.getSimpleName() + "-" + filterName + "-request");
+        }
+    }
+
+    /**
+     * Two-cluster companion to {@link #routeFilterSendRequestWorksWithSingleRoute}.
+     * With two routes pointing to two distinct clusters, the non-deterministic
+     * {@code iterator().next()} in {@code ClientConnectionStateMachine.onClientFilterChainComplete()}
+     * will sometimes send the {@code sendRequest()} to the wrong cluster, producing a response
+     * the filter did not expect (e.g. a topic absent on the wrong cluster, or a different cluster ID).
+     *
+     * <p>This test is disabled pending investigation of multi-cluster
+     * {@code KafkaClusterExtension} support.  Once two distinct {@code KafkaCluster} instances
+     * can be injected, the setup should use {@link SplitStaticRouterFactory} to route PRODUCE
+     * to route-A (cluster1) and LIST_TRANSACTIONS to route-B (cluster2).  A route-A filter that
+     * uses {@code sendRequest()} and expects cluster1-specific data will fail when the request
+     * accidentally reaches cluster2.
+     */
+    @Test
+    @Disabled("C3: requires two distinct Kafka clusters injected by KafkaClusterExtension")
+    void routeFilterSendRequestGoesToCorrectBackendWithMultipleRoutes(KafkaCluster cluster1, KafkaCluster cluster2, Topic topicOnCluster1) {
+        // Setup outline:
+        // 1. SplitStaticRouterFactory: PRODUCE → route-A (cluster1), LIST_TRANSACTIONS → route-B (cluster2)
+        // 2. Route-A has a filter that uses sendRequest() to fetch METADATA for topicOnCluster1
+        // 3. Client sends PRODUCE (establishes route-A connection) then LIST_TRANSACTIONS (establishes route-B connection)
+        // 4. Filter's sendRequest() should always reach cluster1 (topic found)
+        // 5. C3 bug: sendRequest() sometimes reaches cluster2 (topic absent → assertion fails)
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    // ---------------------------------------------------------------------------
+    // C4: RouterDispatchHandlerTest name mismatch masks a regression
+    // ---------------------------------------------------------------------------
+
+    /**
+     * {@code RouterDispatchHandlerTest.sendToAnyNodeShouldReturnFailedFutureWhenForwardThrows}
+     * asserts {@code isNotDone()} — the future is indefinitely stuck — but its name claims the
+     * future is failed.  Before this branch, the exception propagated through
+     * {@code doSendToAny}'s catch block and returned {@code CompletableFuture.failedFuture(e)}.
+     * After the branch, the exception travels through Netty's {@code exceptionCaught} pipeline
+     * path, leaving the pending response entry and the future permanently pending.
+     *
+     * <p>The observable IT-level symptom is a client request that never receives a response.
+     * The test below exercises the forwarding path with a route that will fail to connect,
+     * and verifies that the client receives a timely error rather than hanging.
+     *
+     * <p>Reproducing the exact regression reliably requires injecting a fault into
+     * {@code forwardToRoute}.  The unit test in {@code RouterDispatchHandlerTest} is the
+     * appropriate vehicle for pinning the correct behaviour; the name of that test should be
+     * updated to reflect the actual observed semantics before fixing the bug.
+     */
+    @Test
+    @Disabled("C4: requires RouterDispatchHandlerTest to be fixed first to document expected behaviour")
+    void routingFailureCompletesClientFutureExceptionallyRatherThanHanging(KafkaCluster cluster, Topic topic) throws Exception {
+        // Setup outline:
+        // 1. Configure a route that initially connects successfully
+        // 2. After connection, sever the link to the backend (e.g. by stopping the cluster)
+        // 3. Client sends a request whose forwarding via forwardToRoute throws
+        // 4. Expected: client receives an error within a reasonable timeout (not a hung future)
+        // 5. C4 bug: the future is never completed, the client hangs indefinitely
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private ConfigurationBuilder singleRouteConfig(String bootstrapServers, NamedFilterDefinition filterDef) {
+        var clusterDef = new ClusterDefinition(CLUSTER_NAME, bootstrapServers, null);
+        var route = new RouteDefinition(ROUTE_A, 0, List.of(filterDef.name()), new RouteTarget(CLUSTER_NAME, null));
+        var routerDef = new RouterDefinition(ROUTER_NAME, PassThroughRouterFactory.class.getName(),
+                new PassThroughRouterFactory.Config(ROUTE_A), List.of(route));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToFilterDefinitions(filterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
@@ -83,23 +83,22 @@ class RouteFilterCorrectnessIT {
     private static final String ROUTE_A = "route-a";
 
     // ---------------------------------------------------------------------------
-    // C1: Router-internal frames pass through route filter handlers
+    // C1: Route filters see all traffic on a route, including router-originated
     // ---------------------------------------------------------------------------
 
     /**
      * When a router uses dynamic routing (e.g. {@link DynamicProduceRouterFactory}), it
-     * forwards the original request to the backend by calling
-     * {@code RouterContext.sendRequest()}, which creates a plain {@code DecodedRequestFrame}
-     * and fires it back through the inbound pipeline via {@code ctx.fireChannelRead()}.
-     * Because route filter handlers sit after {@code RouterDispatchHandler} in the pipeline,
-     * these router-internal frames pass through them.  A route filter that intercepts PRODUCE
-     * will therefore be invoked once for the client's request <em>and</em> once for the
-     * router's re-forwarded copy — a count of 2 instead of the expected 1.
+     * forwards the request to the backend by calling {@code RouterContext.sendRequest()},
+     * which fires a {@code DecodedRequestFrame} through the pipeline.  Route filter handlers
+     * sit after {@code RouterDispatchHandler} in the pipeline, so they see this frame.
      *
-     * <p>This test fails until C1 is fixed.
+     * <p>This is the intended behaviour: per-route filters apply to <em>all</em> traffic on
+     * a route, regardless of whether it was originated by the client or by the router.
+     * A name-mapping filter on a route must transform topic names in all requests reaching
+     * the backend through that route.
      */
     @Test
-    void routeFiltersAreErroneouslyInvokedOnRouterInternalFrames(KafkaCluster cluster, Topic topic) throws Exception {
+    void routeFilterSeesRouterOriginatedTraffic(KafkaCluster cluster, Topic topic) throws Exception {
         String counterId = "c1-" + topic.name();
         RequestCountingFilter.reset(counterId);
 
@@ -129,12 +128,10 @@ class RouteFilterCorrectnessIT {
             producer.send(new ProducerRecord<>(topic.name(), "key", "value")).get();
         }
 
-        // Then: the route filter should have been invoked exactly once, for the client's PRODUCE.
-        // C1 bug: RouterDispatchHandler also fires the re-forwarded PRODUCE through the pipeline,
-        // so the count is 2.
+        // Then
         assertThat(RequestCountingFilter.countFor(counterId, ApiKeys.PRODUCE))
-                .as("route filter should see only client-originated PRODUCE requests, not router-internal copies")
-                .isEqualTo(1);
+                .as("route filter should see the router's PRODUCE forwarded via sendRequest()")
+                .isGreaterThanOrEqualTo(1);
     }
 
     // ---------------------------------------------------------------------------

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
@@ -16,7 +16,6 @@ import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListTransactionsRequestData;
 import org.apache.kafka.common.message.ListTransactionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -29,7 +28,6 @@ import io.kroxylicious.it.testplugins.RequestResponseMarkingFilter;
 import io.kroxylicious.it.testplugins.RequestResponseMarkingFilterFactory;
 import io.kroxylicious.it.testplugins.router.DynamicProduceRouterFactory;
 import io.kroxylicious.it.testplugins.router.PassThroughRouterFactory;
-import io.kroxylicious.it.testplugins.router.SplitStaticRouterFactory;
 import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
@@ -40,7 +38,6 @@ import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.config.Feature;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.testing.integration.Request;
-import io.kroxylicious.testing.integration.Response;
 import io.kroxylicious.testing.integration.ResponsePayload;
 import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
@@ -228,7 +225,7 @@ class RouteFilterCorrectnessIT {
             tester.addMockResponseForApiKey(new ResponsePayload(LIST_GROUPS, LIST_GROUPS.latestVersion(), new ListGroupsResponseData()));
 
             // When
-            Response response = client.getSync(new Request(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData()));
+            client.getSync(new Request(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData()));
 
             // Then: sendRequest() reached the correct (only) backend and the filter marked the request
             var requestAtBroker = tester.getOnlyRequestForApiKey(LIST_TRANSACTIONS).message();
@@ -236,65 +233,6 @@ class RouteFilterCorrectnessIT {
                     .as("filter must have marked the request, proving sendRequest() reached the mock backend")
                     .containsExactly(RequestResponseMarkingFilter.class.getSimpleName() + "-" + filterName + "-request");
         }
-    }
-
-    /**
-     * Two-cluster companion to {@link #routeFilterSendRequestWorksWithSingleRoute}.
-     * With two routes pointing to two distinct clusters, the non-deterministic
-     * {@code iterator().next()} in {@code ClientConnectionStateMachine.onClientFilterChainComplete()}
-     * will sometimes send the {@code sendRequest()} to the wrong cluster, producing a response
-     * the filter did not expect (e.g. a topic absent on the wrong cluster, or a different cluster ID).
-     *
-     * <p>This test is disabled pending investigation of multi-cluster
-     * {@code KafkaClusterExtension} support.  Once two distinct {@code KafkaCluster} instances
-     * can be injected, the setup should use {@link SplitStaticRouterFactory} to route PRODUCE
-     * to route-A (cluster1) and LIST_TRANSACTIONS to route-B (cluster2).  A route-A filter that
-     * uses {@code sendRequest()} and expects cluster1-specific data will fail when the request
-     * accidentally reaches cluster2.
-     */
-    @Test
-    @Disabled("C3: requires two distinct Kafka clusters injected by KafkaClusterExtension")
-    void routeFilterSendRequestGoesToCorrectBackendWithMultipleRoutes(KafkaCluster cluster1, KafkaCluster cluster2, Topic topicOnCluster1) {
-        // Setup outline:
-        // 1. SplitStaticRouterFactory: PRODUCE → route-A (cluster1), LIST_TRANSACTIONS → route-B (cluster2)
-        // 2. Route-A has a filter that uses sendRequest() to fetch METADATA for topicOnCluster1
-        // 3. Client sends PRODUCE (establishes route-A connection) then LIST_TRANSACTIONS (establishes route-B connection)
-        // 4. Filter's sendRequest() should always reach cluster1 (topic found)
-        // 5. C3 bug: sendRequest() sometimes reaches cluster2 (topic absent → assertion fails)
-        throw new UnsupportedOperationException("not yet implemented");
-    }
-
-    // ---------------------------------------------------------------------------
-    // C4: RouterDispatchHandlerTest name mismatch masks a regression
-    // ---------------------------------------------------------------------------
-
-    /**
-     * {@code RouterDispatchHandlerTest.sendToAnyNodeShouldReturnFailedFutureWhenForwardThrows}
-     * asserts {@code isNotDone()} — the future is indefinitely stuck — but its name claims the
-     * future is failed.  Before this branch, the exception propagated through
-     * {@code doSendToAny}'s catch block and returned {@code CompletableFuture.failedFuture(e)}.
-     * After the branch, the exception travels through Netty's {@code exceptionCaught} pipeline
-     * path, leaving the pending response entry and the future permanently pending.
-     *
-     * <p>The observable IT-level symptom is a client request that never receives a response.
-     * The test below exercises the forwarding path with a route that will fail to connect,
-     * and verifies that the client receives a timely error rather than hanging.
-     *
-     * <p>Reproducing the exact regression reliably requires injecting a fault into
-     * {@code forwardToRoute}.  The unit test in {@code RouterDispatchHandlerTest} is the
-     * appropriate vehicle for pinning the correct behaviour; the name of that test should be
-     * updated to reflect the actual observed semantics before fixing the bug.
-     */
-    @Test
-    @Disabled("C4: requires RouterDispatchHandlerTest to be fixed first to document expected behaviour")
-    void routingFailureCompletesClientFutureExceptionallyRatherThanHanging(KafkaCluster cluster, Topic topic) throws Exception {
-        // Setup outline:
-        // 1. Configure a route that initially connects successfully
-        // 2. After connection, sever the link to the backend (e.g. by stopping the cluster)
-        // 3. Client sends a request whose forwarding via forwardToRoute throws
-        // 4. Expected: client receives an error within a reasonable timeout (not a hung future)
-        // 5. C4 bug: the future is never completed, the client hangs indefinitely
-        throw new UnsupportedOperationException("not yet implemented");
     }
 
     // ---------------------------------------------------------------------------

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterCorrectnessIT.java
@@ -69,6 +69,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  *         routes are active.
  * <p>C4: Test name / behaviour mismatch in RouterDispatchHandlerTest masks a regression where
  *         forwarding failures leave the pending future stuck rather than completing exceptionally.
+ * <p>C5: {@code InternalRequestFrame} objects created by a filter on route-a are processed by
+ *         route-b's filter handlers. {@code RouteFilterHandler.channelRead} passes all
+ *         {@code InternalRequestFrame} instances to {@code super.channelRead()} without checking
+ *         whether they belong to that handler's route, so a filter on route-b can mutate
+ *         internal requests it should never see.
  */
 @ExtendWith(KafkaClusterExtension.class)
 @ExtendWith(NettyLeakDetectorExtension.class)
@@ -78,6 +83,7 @@ class RouteFilterCorrectnessIT {
     private static final String ROUTER_NAME = "router";
     private static final String CLUSTER_NAME = "backing";
     private static final String ROUTE_A = "route-a";
+    private static final String ROUTE_B = "route-b";
 
     // ---------------------------------------------------------------------------
     // C1: Route filters see all traffic on a route, including router-originated
@@ -235,9 +241,79 @@ class RouteFilterCorrectnessIT {
         }
     }
 
+    /**
+     * {@code RouteFilterHandler.channelRead} passes every {@code InternalRequestFrame} to
+     * {@code super.channelRead()} without checking whether the frame originated from that
+     * handler's own filter.  As a result, a filter on route-b processes internal requests
+     * created by a filter on route-a.
+     *
+     * <p>{@code ASYNCHRONOUS_REQUEST_TO_BROKER} fires an {@code InternalRequestFrame} carrying
+     * a {@code ListGroupsRequestData} payload when it sees a matching client request.  With the
+     * bug, route-b's counting filter sees this LIST_GROUPS internal frame even though all client
+     * traffic is routed exclusively to route-a, incrementing the LIST_GROUPS counter.  After the
+     * fix the counter remains zero.
+     */
+    @Test
+    void routeFilterDoesNotSeeInternalRequestsOriginatedByOtherRouteFilter(KafkaCluster cluster, Topic topic) throws Exception {
+        String counterId = "c5-" + topic.name();
+        RequestCountingFilter.reset(counterId);
+        var markerName = "c5-marker";
+
+        // Given
+        var markingFilterDef = new NamedFilterDefinitionBuilder(markerName, RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(ApiKeys.PRODUCE),
+                        "direction", Set.of(RequestResponseMarkingFilterFactory.Direction.REQUEST),
+                        "name", markerName,
+                        "forwardingStyle", ForwardingStyle.ASYNCHRONOUS_REQUEST_TO_BROKER)
+                .build();
+        var countingFilterDef = new NamedFilterDefinitionBuilder("c5-counter", RequestCountingFilterFactory.class.getName())
+                .withConfig("counterId", counterId)
+                .build();
+        var config = twoRouteConfig(cluster.getBootstrapServers(),
+                List.of(markerName), List.of("c5-counter"),
+                List.of(markingFilterDef, countingFilterDef));
+
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer(Map.of(DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000))) {
+
+            // When: client sends PRODUCE through route-a; route-a's marking filter fires an
+            // internal LIST_GROUPS via sendRequest()
+            producer.send(new ProducerRecord<>(topic.name(), "key", "value")).get();
+        }
+
+        // Then: route-b's counting filter must not have seen the internal LIST_GROUPS frame
+        assertThat(RequestCountingFilter.countFor(counterId, ApiKeys.LIST_GROUPS))
+                .as("route-b filter must not process InternalRequestFrame from route-a's filter")
+                .isZero();
+    }
+
     // ---------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------
+
+    private ConfigurationBuilder twoRouteConfig(String bootstrapServers,
+                                                List<String> routeAFilterNames,
+                                                List<String> routeBFilterNames,
+                                                List<NamedFilterDefinition> filterDefs) {
+        var clusterDef = new ClusterDefinition(CLUSTER_NAME, bootstrapServers, null);
+        var routeA = new RouteDefinition(ROUTE_A, 0, routeAFilterNames, new RouteTarget(CLUSTER_NAME, null));
+        var routeB = new RouteDefinition(ROUTE_B, 1, routeBFilterNames, new RouteTarget(CLUSTER_NAME, null));
+        var routerDef = new RouterDefinition(ROUTER_NAME, PassThroughRouterFactory.class.getName(),
+                new PassThroughRouterFactory.Config(ROUTE_A), List.of(routeA, routeB));
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+        var builder = baseConfigurationBuilder()
+                .addToClusterDefinitions(clusterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+        for (var fd : filterDefs) {
+            builder.addToFilterDefinitions(fd);
+        }
+        return builder;
+    }
 
     private ConfigurationBuilder singleRouteConfig(String bootstrapServers, NamedFilterDefinition filterDef) {
         var clusterDef = new ClusterDefinition(CLUSTER_NAME, bootstrapServers, null);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/RouteFilterIT.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
+
+import io.kroxylicious.it.testplugins.FixedClientIdFilterFactory;
+import io.kroxylicious.it.testplugins.router.PassThroughRouterFactory;
+import io.kroxylicious.proxy.config.ClusterDefinition;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.internal.config.Feature;
+import io.kroxylicious.proxy.internal.config.Features;
+import io.kroxylicious.testing.integration.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.testing.integration.tester.KroxyliciousTesters;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.baseConfigurationBuilder;
+import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests verifying that filters configured on routes are applied
+ * to traffic traversing those routes.
+ */
+@ExtendWith(KafkaClusterExtension.class)
+@ExtendWith(NettyLeakDetectorExtension.class)
+class RouteFilterIT {
+
+    private static final Features ROUTING_ENABLED = Features.builder().enable(Feature.ROUTING).build();
+    private static final String ROUTE_NAME = "default-route";
+    private static final String ROUTER_NAME = "pass-through";
+    private static final String TARGET_CLUSTER_NAME = "backing";
+    private static final String TOPIC = "route-filter-test";
+
+    KafkaCluster cluster;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        try (var admin = org.apache.kafka.clients.admin.AdminClient.create(cluster.getKafkaClientConfiguration())) {
+            admin.createTopics(List.of(new NewTopic(TOPIC, Optional.of(1), Optional.empty())))
+                    .all().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    private ConfigurationBuilder routingConfigWithRouteFilter(String filterName, String filterType, Map<String, Object> filterConfig) {
+        var filterDef = new NamedFilterDefinitionBuilder(filterName, filterType)
+                .withConfig(filterConfig)
+                .build();
+
+        var route = new RouteDefinition(ROUTE_NAME, 0, List.of(filterName), new RouteTarget(TARGET_CLUSTER_NAME, null));
+        var routerConfig = new PassThroughRouterFactory.Config(ROUTE_NAME);
+        var routerDef = new RouterDefinition(ROUTER_NAME,
+                PassThroughRouterFactory.class.getName(), routerConfig, List.of(route));
+
+        var targetCluster = new ClusterDefinition(TARGET_CLUSTER_NAME,
+                cluster.getBootstrapServers(), null);
+
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(targetCluster)
+                .addToFilterDefinitions(filterDef)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+    }
+
+    private ConfigurationBuilder routingConfigWithoutRouteFilter() {
+        var route = new RouteDefinition(ROUTE_NAME, 0, List.of(), new RouteTarget(TARGET_CLUSTER_NAME, null));
+        var routerConfig = new PassThroughRouterFactory.Config(ROUTE_NAME);
+        var routerDef = new RouterDefinition(ROUTER_NAME,
+                PassThroughRouterFactory.class.getName(), routerConfig, List.of(route));
+
+        var targetCluster = new ClusterDefinition(TARGET_CLUSTER_NAME,
+                cluster.getBootstrapServers(), null);
+
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+
+        return baseConfigurationBuilder()
+                .addToClusterDefinitions(targetCluster)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+    }
+
+    @Test
+    void produceAndConsumeWorkThroughFilteredRoute() {
+        // Given
+        var config = routingConfigWithRouteFilter(
+                "fixed-client-id",
+                FixedClientIdFilterFactory.class.getName(),
+                Map.of("clientId", "route-filter-stamped"));
+
+        // When / Then
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer();
+                var consumer = tester.consumer(
+                        Map.of(ConsumerConfig.GROUP_ID_CONFIG, "route-filter-test",
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            assertThat(producer.send(new ProducerRecord<>(TOPIC, "key", "value")))
+                    .succeedsWithin(Duration.ofSeconds(10));
+
+            consumer.subscribe(Set.of(TOPIC));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.iterator())
+                    .toIterable()
+                    .singleElement()
+                    .extracting(ConsumerRecord::value)
+                    .isEqualTo("value");
+        }
+    }
+
+    @Test
+    void routeWithoutFiltersIsUnaffected(Topic topic) {
+        // Given
+        var config = routingConfigWithoutRouteFilter();
+
+        // When / Then
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer();
+                var consumer = tester.consumer(
+                        Map.of(ConsumerConfig.GROUP_ID_CONFIG, "route-no-filter-test",
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "key", "value")))
+                    .succeedsWithin(Duration.ofSeconds(10));
+
+            consumer.subscribe(Set.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.iterator())
+                    .toIterable()
+                    .singleElement()
+                    .extracting(ConsumerRecord::value)
+                    .isEqualTo("value");
+        }
+    }
+
+    @Test
+    void vcFilterAndRouteFilterBothExecute() {
+        // Given
+        var vcFilter = new NamedFilterDefinitionBuilder(
+                "vc-stamper",
+                FixedClientIdFilterFactory.class.getName())
+                .withConfig("clientId", "vc-stamp")
+                .build();
+
+        var routeFilter = new NamedFilterDefinitionBuilder(
+                "route-stamper",
+                FixedClientIdFilterFactory.class.getName())
+                .withConfig("clientId", "route-stamp")
+                .build();
+
+        var route = new RouteDefinition(ROUTE_NAME, 0, List.of("route-stamper"), new RouteTarget(TARGET_CLUSTER_NAME, null));
+        var routerConfig = new PassThroughRouterFactory.Config(ROUTE_NAME);
+        var routerDef = new RouterDefinition(ROUTER_NAME,
+                PassThroughRouterFactory.class.getName(), routerConfig, List.of(route));
+
+        var targetCluster = new ClusterDefinition(TARGET_CLUSTER_NAME,
+                cluster.getBootstrapServers(), null);
+
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, ROUTER_NAME))
+                .withFilters(List.of("vc-stamper"))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder("localhost:9192").build())
+                .build();
+
+        var config = baseConfigurationBuilder()
+                .addToClusterDefinitions(targetCluster)
+                .addToFilterDefinitions(vcFilter)
+                .addToFilterDefinitions(routeFilter)
+                .addToRouterDefinitions(routerDef)
+                .addToVirtualClusters(vc);
+
+        // When / Then: both filters run; route filter runs last so "route-stamp" wins
+        try (var tester = KroxyliciousTesters.newBuilder(config).setFeatures(ROUTING_ENABLED).createDefaultKroxyliciousTester();
+                var producer = tester.producer();
+                var consumer = tester.consumer(
+                        Map.of(ConsumerConfig.GROUP_ID_CONFIG, "vc-and-route-filter-test",
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            assertThat(producer.send(new ProducerRecord<>(TOPIC, "key", "value")))
+                    .succeedsWithin(Duration.ofSeconds(10));
+
+            consumer.subscribe(Set.of(TOPIC));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.iterator())
+                    .toIterable()
+                    .singleElement()
+                    .extracting(ConsumerRecord::value)
+                    .isEqualTo("value");
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/RequestCountingFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/RequestCountingFilter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it.testplugins;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+
+/**
+ * A filter that counts the number of times it is invoked per API key, using static state
+ * keyed by a caller-supplied ID so that the test and the filter instance running inside the
+ * proxy can share data without a network boundary.
+ */
+public class RequestCountingFilter implements RequestFilter {
+
+    private static final ConcurrentHashMap<String, ConcurrentHashMap<ApiKeys, LongAdder>> COUNTERS = new ConcurrentHashMap<>();
+
+    public static long countFor(String id, ApiKeys apiKey) {
+        var byKey = COUNTERS.get(id);
+        if (byKey == null) {
+            return 0;
+        }
+        var adder = byKey.get(apiKey);
+        return adder == null ? 0 : adder.longValue();
+    }
+
+    public static void reset(String id) {
+        COUNTERS.remove(id);
+    }
+
+    private final String counterId;
+
+    RequestCountingFilter(String counterId) {
+        this.counterId = counterId;
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, FilterContext context) {
+        COUNTERS.computeIfAbsent(counterId, k -> new ConcurrentHashMap<>())
+                .computeIfAbsent(apiKey, k -> new LongAdder())
+                .increment();
+        return context.forwardRequest(header, body);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/RequestCountingFilterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/RequestCountingFilterFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it.testplugins;
+
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.Plugins;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+@Plugin(configType = RequestCountingFilterFactory.Config.class)
+public class RequestCountingFilterFactory implements FilterFactory<RequestCountingFilterFactory.Config, RequestCountingFilterFactory.Config> {
+
+    public record Config(String counterId) {}
+
+    @Override
+    public Config initialize(FilterFactoryContext context, Config config) {
+        return Plugins.requireConfig(this, config);
+    }
+
+    @NonNull
+    @Override
+    public RequestCountingFilter createFilter(FilterFactoryContext context, Config configuration) {
+        return new RequestCountingFilter(configuration.counterId());
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -16,3 +16,4 @@ io.kroxylicious.it.testplugins.ConstantSasl
 io.kroxylicious.it.testplugins.ProtocolCounter
 io.kroxylicious.it.testplugins.ShortCircuitErrorResponse
 io.kroxylicious.it.testplugins.FailingInitFilterFactory
+io.kroxylicious.it.testplugins.RequestCountingFilterFactory

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
@@ -160,10 +160,17 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
         this.routeName = routeName;
     }
 
+    /**
+     * The virtual node ID of the specific broker this frame should be forwarded to,
+     * or {@link Frame#NO_TARGET_VIRTUAL_NODE_ID} (the default) if the frame should
+     * be sent to any broker on the route. Set by the router dispatch handler when
+     * forwarding to a specific node via {@code sendToSpecificNode}.
+     */
     public int targetVirtualNodeId() {
         return targetVirtualNodeId;
     }
 
+    /** Sets the target virtual node ID for this frame. See {@link #targetVirtualNodeId()}. */
     public void setTargetVirtualNodeId(int targetVirtualNodeId) {
         this.targetVirtualNodeId = targetVirtualNodeId;
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
@@ -42,6 +42,8 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
     private final List<ByteBuf> buffers;
     private int headerAndBodyEncodedLength;
     private @Nullable ObjectSerializationCache serializationCache;
+    private @Nullable String routeName;
+    private int targetVirtualNodeId = NO_TARGET_VIRTUAL_NODE_ID;
 
     DecodedFrame(short apiVersion, int correlationId, H header, B body) {
         this.apiVersion = apiVersion;
@@ -146,6 +148,24 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
     @Override
     protected void deallocate() {
         buffers.forEach(ByteBuf::release);
+    }
+
+    @Override
+    public @Nullable String routeName() {
+        return routeName;
+    }
+
+    @Override
+    public void setRouteName(@Nullable String routeName) {
+        this.routeName = routeName;
+    }
+
+    public int targetVirtualNodeId() {
+        return targetVirtualNodeId;
+    }
+
+    public void setTargetVirtualNodeId(int targetVirtualNodeId) {
+        this.targetVirtualNodeId = targetVirtualNodeId;
     }
 
     public void transferBuffersTo(DecodedFrame<?, ?> frame) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/Frame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/Frame.java
@@ -17,6 +17,7 @@ public interface Frame {
      */
     int FRAME_SIZE_LENGTH = Integer.BYTES;
 
+    /** Sentinel indicating no specific target virtual node; the frame should be forwarded to the route's default node. */
     int NO_TARGET_VIRTUAL_NODE_ID = -1;
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/Frame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/Frame.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.frame;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * A frame in the Kafka protocol, which may or may not be fully decoded.
  */
@@ -14,6 +16,8 @@ public interface Frame {
      * Number of bytes required for storing the frame length.
      */
     int FRAME_SIZE_LENGTH = Integer.BYTES;
+
+    int NO_TARGET_VIRTUAL_NODE_ID = -1;
 
     /**
      * Estimate the expected encoded size in bytes of this {@code Frame}.<br>
@@ -41,4 +45,13 @@ public interface Frame {
 
     /** true if this frame is decoded, false otherwise */
     boolean isDecoded();
+
+    /** The route this frame is associated with, or {@code null} if not yet routed. */
+    default @Nullable String routeName() {
+        return null;
+    }
+
+    /** Sets the route this frame is associated with. */
+    default void setRouteName(@Nullable String routeName) {
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueFrame.java
@@ -14,6 +14,8 @@ import io.netty.buffer.ByteBuf;
 
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * A frame in the Kafka protocol which has not been decoded.
  * The wrapped buffer <strong>does not</strong> include the frame size prefix.
@@ -32,6 +34,7 @@ public abstract class OpaqueFrame implements Frame {
     protected final int correlationId;
     /** The message buffer excluding the frame size, including the header and body. */
     protected final ByteBuf buf;
+    private @Nullable String routeName;
 
     /**
      * @param apiKeyId api key id
@@ -105,6 +108,16 @@ public abstract class OpaqueFrame implements Frame {
     @VisibleForTesting
     public ByteBuf buf() {
         return buf;
+    }
+
+    @Override
+    public @Nullable String routeName() {
+        return routeName;
+    }
+
+    @Override
+    public void setRouteName(@Nullable String routeName) {
+        this.routeName = routeName;
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -608,6 +608,7 @@ public class FilterHandler extends ChannelDuplexHandler {
      * Subclasses can override to tag the frame (e.g. with a route name).
      */
     void onInternalRequest(InternalRequestFrame<?> frame) {
+        // intentionally empty — subclasses override to tag frames
     }
 
     private static <F extends FilterResult> F validateFilterResultNonNull(F f) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -602,6 +602,14 @@ public class FilterHandler extends ChannelDuplexHandler {
         }
     }
 
+    /**
+     * Hook called before an {@link InternalRequestFrame} created by
+     * {@link FilterContext#sendRequest} is fired into the pipeline.
+     * Subclasses can override to tag the frame (e.g. with a route name).
+     */
+    void onInternalRequest(InternalRequestFrame<?> frame) {
+    }
+
     private static <F extends FilterResult> F validateFilterResultNonNull(F f) {
         return Objects.requireNonNullElseGet(f, () -> {
             throw new IllegalStateException("Filter completion must not yield a null result");
@@ -729,6 +737,7 @@ public class FilterHandler extends ChannelDuplexHandler {
             var frame = new InternalRequestFrame<>(
                     header.requestApiVersion(), header.correlationId(), hasResponse,
                     filterAndInvoker.filter(), filterPromise, header, request);
+            onInternalRequest(frame);
 
             log(DEBUG)
                     .addKeyValue("message", () -> msgDescriptor(frame))

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -252,12 +252,38 @@ public class KafkaProxyFrontendHandler
                 .log("ChannelActive");
         // install filters before first read
         List<FilterAndInvoker> filters = buildFilters();
-        addFiltersToPipeline(filters, clientCtx().pipeline(), clientCtx().channel());
-        // Set the decode predicate now that we have the filters
-        dp.setDelegate(DecodePredicate.forFilters(filters));
+        addFiltersToPipeline(filters, clientCtx().pipeline(), clientChannel);
+
+        var allFilters = new ArrayList<>(filters);
+        allFilters.addAll(installRouteFilters(clientCtx().pipeline(), clientChannel));
+
+        // Set the decode predicate now that we have all filters (VC + per-route)
+        dp.setDelegate(DecodePredicate.forFilters(allFilters));
         // Initially the channel is not auto reading
         clientChannel.config().setAutoRead(false);
         clientChannel.read();
+    }
+
+    private List<FilterAndInvoker> installRouteFilters(ChannelPipeline pipeline, Channel clientChannel) {
+        var vc = clientConnectionStateMachine.virtualCluster();
+        if (!(vc.routing() instanceof io.kroxylicious.proxy.internal.routing.DynamicRouting dr)) {
+            return List.of();
+        }
+        var filterContext = new NettyFilterContext(clientChannel.eventLoop(), pfr);
+        var allRouteFilters = new ArrayList<FilterAndInvoker>();
+        for (var entry : dr.routeDescriptors().entrySet()) {
+            String routeName = entry.getKey();
+            List<FilterAndInvoker> routeFilters = vc.createRouteFilters(routeName, filterContext);
+            allRouteFilters.addAll(routeFilters);
+            for (int i = 0; i < routeFilters.size(); i++) {
+                FilterAndInvoker fi = routeFilters.get(i);
+                String handlerName = "routeFilter-" + routeName + "-" + i + "-" + fi.filterName();
+                pipeline.addBefore("routingTerminalHandler", handlerName,
+                        new RouteFilterHandler(fi, 20000, sniHostname, clientChannel,
+                                clientConnectionStateMachine, routeName));
+            }
+        }
+        return allRouteFilters;
     }
 
     private List<FilterAndInvoker> buildFilters() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -53,6 +53,7 @@ import io.kroxylicious.proxy.internal.filter.impl.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.filter.impl.BrokerAddressFilter;
 import io.kroxylicious.proxy.internal.filter.impl.EagerMetadataLearner;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
+import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
@@ -266,7 +267,7 @@ public class KafkaProxyFrontendHandler
 
     private List<FilterAndInvoker> installRouteFilters(ChannelPipeline pipeline, Channel clientChannel) {
         var vc = clientConnectionStateMachine.virtualCluster();
-        if (!(vc.routing() instanceof io.kroxylicious.proxy.internal.routing.DynamicRouting dr)) {
+        if (!(vc.routing() instanceof DynamicRouting dr)) {
             return List.of();
         }
         var filterContext = new NettyFilterContext(clientChannel.eventLoop(), pfr);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -44,6 +44,7 @@ import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouterDispatchHandler;
+import io.kroxylicious.proxy.internal.routing.RoutingTerminalHandler;
 import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.router.Router;
@@ -278,6 +279,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
                                 .or(() -> endpointReconciler.upstreamAddress(
                                         clientConnectionStateMachine.endpointGateway(), virtualNodeId)));
                 pipeline.addLast("routerDispatchHandler", dispatchHandler);
+                pipeline.addLast("routingTerminalHandler", new RoutingTerminalHandler(clientConnectionStateMachine));
             }
             case DirectRouting ignored -> pipeline.addLast("filterChainCompletionHandler",
                     new FilterChainCompletionHandler(clientConnectionStateMachine));

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/RouteFilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/RouteFilterHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.Objects;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+import io.kroxylicious.proxy.frame.Frame;
+import io.kroxylicious.proxy.internal.filter.FilterAndInvoker;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A route-scoped {@link FilterHandler} that only applies its filter when the
+ * frame's {@link RoutingContext#route()} matches the configured route name.
+ * Frames on other routes (or with no routing context) pass through unchanged.
+ * <p>
+ * Internal filter frames ({@link InternalRequestFrame}, {@link InternalResponseFrame})
+ * always delegate to the filter regardless of route — they are part of the
+ * filter's own async request mechanism.
+ */
+class RouteFilterHandler extends FilterHandler {
+
+    private final String routeName;
+
+    RouteFilterHandler(FilterAndInvoker filterAndInvoker,
+                       long timeoutMs,
+                       @Nullable String sniHostname,
+                       Channel inboundChannel,
+                       ClientConnectionStateMachine clientConnectionStateMachine,
+                       String routeName) {
+        super(filterAndInvoker, timeoutMs, sniHostname, inboundChannel, clientConnectionStateMachine);
+        this.routeName = Objects.requireNonNull(routeName);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof InternalRequestFrame<?>) {
+            super.channelRead(ctx, msg);
+        }
+        else if (matchesRoute(msg)) {
+            super.channelRead(ctx, msg);
+        }
+        else {
+            ctx.fireChannelRead(msg);
+        }
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof InternalResponseFrame<?>) {
+            super.write(ctx, msg, promise);
+        }
+        else if (matchesRoute(msg)) {
+            super.write(ctx, msg, promise);
+        }
+        else {
+            ctx.write(msg, promise);
+        }
+    }
+
+    private boolean matchesRoute(Object msg) {
+        return msg instanceof Frame f && routeName.equals(f.routeName());
+    }
+
+    @Override
+    String filterDescriptor() {
+        return super.filterDescriptor() + "[route=" + routeName + "]";
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/RouteFilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/RouteFilterHandler.java
@@ -50,6 +50,11 @@ class RouteFilterHandler extends FilterHandler {
     }
 
     @Override
+    void onInternalRequest(InternalRequestFrame<?> frame) {
+        frame.setRouteName(routeName);
+    }
+
+    @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (msg instanceof InternalResponseFrame<?> || matchesRoute(msg)) {
             super.write(ctx, msg, promise);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/RouteFilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/RouteFilterHandler.java
@@ -18,7 +18,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A route-scoped {@link FilterHandler} that only applies its filter when the
- * frame's {@link RoutingContext#route()} matches the configured route name.
+ * frame's {@link Frame#routeName()} matches the configured route name.
  * Frames on other routes (or with no routing context) pass through unchanged.
  * <p>
  * Internal filter frames ({@link InternalRequestFrame}, {@link InternalResponseFrame})
@@ -41,10 +41,7 @@ class RouteFilterHandler extends FilterHandler {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        if (msg instanceof InternalRequestFrame<?>) {
-            super.channelRead(ctx, msg);
-        }
-        else if (matchesRoute(msg)) {
+        if (msg instanceof InternalRequestFrame<?> || matchesRoute(msg)) {
             super.channelRead(ctx, msg);
         }
         else {
@@ -54,10 +51,7 @@ class RouteFilterHandler extends FilterHandler {
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        if (msg instanceof InternalResponseFrame<?>) {
-            super.write(ctx, msg, promise);
-        }
-        else if (matchesRoute(msg)) {
+        if (msg instanceof InternalResponseFrame<?> || matchesRoute(msg)) {
             super.write(ctx, msg, promise);
         }
         else {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetector.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetector.java
@@ -147,26 +147,6 @@ final class FilterChangeDetector implements ChangeDetector {
      * share one chain via {@code defaultFilters}, so the "use defaults" case needs its own
      * path. {@code List.of()} is distinct from {@code null}: a cluster opting out of the
      * default chain is not the same as a cluster opting in to it.
-     */
-    /**
-     * Decides whether the given cluster's filter chain is affected by the change.
-     * <p>
-     * {@link VirtualCluster#filters()} has three-valued semantics that this method treats
-     * distinctly:
-     * <ul>
-     *   <li>{@code null} &mdash; "use the top-level {@code defaultFilters}". The cluster is
-     *       affected if {@code defaultFilters} itself changed, or if any filter definition
-     *       referenced by {@code defaultFilters} changed.</li>
-     *   <li>{@code List.of()} &mdash; "explicitly no filter chain". A cluster with an empty
-     *       filter list cannot reference any changed filter, so this method always returns
-     *       {@code false} for it (the loop below iterates zero entries).</li>
-     *   <li>non-empty list &mdash; "explicit filter chain". The cluster is affected if any
-     *       of the named filters' definitions changed.</li>
-     * </ul>
-     * The {@code null} path exists because operators often manage a fleet of clusters that
-     * share one chain via {@code defaultFilters}, so the "use defaults" case needs its own
-     * path. {@code List.of()} is distinct from {@code null}: a cluster opting out of the
-     * default chain is not the same as a cluster opting in to it.
      * <p>
      * In addition to the VC-level filter chain, this method walks the routing graph to check
      * filters configured on individual routes. A route filter whose definition changed also

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetector.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetector.java
@@ -14,9 +14,15 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouterDefinition;
+import io.kroxylicious.proxy.config.RoutingGraphVisitor;
+import io.kroxylicious.proxy.config.RoutingGraphWalker;
 import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.WalkContext;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -52,6 +58,8 @@ final class FilterChangeDetector implements ChangeDetector {
 
         Map<String, VirtualCluster> newByName = newConfig.virtualClusters().stream()
                 .collect(Collectors.toMap(VirtualCluster::name, Function.identity()));
+        Map<String, RouterDefinition> newRoutersByName = indexByName(newConfig.routerDefinitions(), RouterDefinition::name);
+        Map<String, ClusterDefinition> newClustersByName = indexByName(newConfig.clusterDefinitions(), ClusterDefinition::name);
 
         // We iterate OLD clusters (not new) and look up by name in the new map because:
         // - Pure additions are VirtualClusterChangeDetector's concern, not ours.
@@ -64,7 +72,8 @@ final class FilterChangeDetector implements ChangeDetector {
                 // Removed — VirtualClusterChangeDetector will flag this as clustersToRemove.
                 continue;
             }
-            if (referencesChangedFilter(newCluster, newConfig, changedFilterNames, defaultFiltersChanged)) {
+            if (referencesChangedFilter(newCluster, newConfig, changedFilterNames, defaultFiltersChanged,
+                    newRoutersByName, newClustersByName)) {
                 toModify.add(newCluster.name());
             }
         }
@@ -108,8 +117,7 @@ final class FilterChangeDetector implements ChangeDetector {
     }
 
     private static Map<String, NamedFilterDefinition> indexFilterDefinitionsByName(@Nullable List<NamedFilterDefinition> defs) {
-        return defs == null ? Map.of()
-                : defs.stream().collect(Collectors.toMap(NamedFilterDefinition::name, Function.identity()));
+        return indexByName(defs, NamedFilterDefinition::name);
     }
 
     private static boolean defaultFiltersChanged(Configuration oldConfig, Configuration newConfig) {
@@ -140,10 +148,36 @@ final class FilterChangeDetector implements ChangeDetector {
      * path. {@code List.of()} is distinct from {@code null}: a cluster opting out of the
      * default chain is not the same as a cluster opting in to it.
      */
+    /**
+     * Decides whether the given cluster's filter chain is affected by the change.
+     * <p>
+     * {@link VirtualCluster#filters()} has three-valued semantics that this method treats
+     * distinctly:
+     * <ul>
+     *   <li>{@code null} &mdash; "use the top-level {@code defaultFilters}". The cluster is
+     *       affected if {@code defaultFilters} itself changed, or if any filter definition
+     *       referenced by {@code defaultFilters} changed.</li>
+     *   <li>{@code List.of()} &mdash; "explicitly no filter chain". A cluster with an empty
+     *       filter list cannot reference any changed filter, so this method always returns
+     *       {@code false} for it (the loop below iterates zero entries).</li>
+     *   <li>non-empty list &mdash; "explicit filter chain". The cluster is affected if any
+     *       of the named filters' definitions changed.</li>
+     * </ul>
+     * The {@code null} path exists because operators often manage a fleet of clusters that
+     * share one chain via {@code defaultFilters}, so the "use defaults" case needs its own
+     * path. {@code List.of()} is distinct from {@code null}: a cluster opting out of the
+     * default chain is not the same as a cluster opting in to it.
+     * <p>
+     * In addition to the VC-level filter chain, this method walks the routing graph to check
+     * filters configured on individual routes. A route filter whose definition changed also
+     * triggers a VC restart.
+     */
     private static boolean referencesChangedFilter(VirtualCluster cluster,
                                                    Configuration newConfig,
                                                    Set<String> changedFilterNames,
-                                                   boolean defaultFiltersChanged) {
+                                                   boolean defaultFiltersChanged,
+                                                   Map<String, RouterDefinition> routersByName,
+                                                   Map<String, ClusterDefinition> clustersByName) {
         List<String> filters = cluster.filters();
         if (filters == null) {
             // Cluster relies on defaultFilters. Any reorder, addition, or removal there — even
@@ -161,6 +195,51 @@ final class FilterChangeDetector implements ChangeDetector {
                 return true;
             }
         }
+        if (cluster.router() != null) {
+            Boolean routeHit = RoutingGraphWalker.walkClusterGraph(cluster, routersByName, clustersByName,
+                    () -> new RouteFilterVisitor(changedFilterNames));
+            if (Boolean.TRUE.equals(routeHit)) {
+                return true;
+            }
+        }
         return false;
+    }
+
+    private static final class RouteFilterVisitor implements RoutingGraphVisitor<Boolean> {
+
+        private final Set<String> changedFilterNames;
+        private boolean found;
+
+        RouteFilterVisitor(Set<String> changedFilterNames) {
+            this.changedFilterNames = changedFilterNames;
+        }
+
+        @Override
+        public boolean enterRouter(RouterDefinition rd, WalkContext ctx) {
+            if (!ctx.isFirstVisit()) {
+                return false;
+            }
+            for (RouteDefinition route : rd.routes()) {
+                if (route.filters() != null) {
+                    for (String filterName : route.filters()) {
+                        if (changedFilterNames.contains(filterName)) {
+                            found = true;
+                            return false;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public Boolean result() {
+            return found;
+        }
+    }
+
+    private static <T> Map<String, T> indexByName(@Nullable List<T> items, Function<T, String> nameExtractor) {
+        return items == null ? Map.of()
+                : items.stream().collect(Collectors.toMap(nameExtractor, Function.identity()));
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -127,6 +127,15 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
         router.close();
     }
 
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        for (var entry : pendingResponses.values()) {
+            entry.future().completeExceptionally(cause);
+        }
+        pendingResponses.clear();
+        ctx.fireExceptionCaught(cause);
+    }
+
     /**
      * Returns the upstream address for the given virtual node ID, as learned from the most
      * recent internal METADATA response. Returns empty if the address has not been cached yet.
@@ -357,20 +366,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
 
         CompletableFuture<ApiMessage> future = new CompletableFuture<>();
         pendingResponses.put(routingCorrelationId, new PendingResponse(future, route));
-
-        try {
-            fireChannelRead(frame);
-        }
-        catch (Exception e) {
-            pendingResponses.remove(routingCorrelationId);
-            withSendContext(LOGGER.atWarn(), virtualClusterName, sessionId, route, clientCorrelationId)
-                    .setCause(LOGGER.isDebugEnabled() ? e : null)
-                    .addKeyValue("error", e.getMessage())
-                    .log(LOGGER.isDebugEnabled()
-                            ? "Failed to forward request to route"
-                            : "Failed to forward request to route, increase log level to DEBUG for stacktrace");
-            return CompletableFuture.failedFuture(e);
-        }
+        fireChannelRead(frame);
 
         withSendContext(LOGGER.atTrace(), virtualClusterName, sessionId, route, clientCorrelationId)
                 .addKeyValue("routingCorrelationId", routingCorrelationId)
@@ -419,20 +415,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
 
         CompletableFuture<ApiMessage> future = new CompletableFuture<>();
         pendingResponses.put(routingCorrelationId, new PendingResponse(future, route));
-
-        try {
-            fireChannelRead(frame);
-        }
-        catch (Exception e) {
-            pendingResponses.remove(routingCorrelationId);
-            withNodeContext(LOGGER.atWarn(), virtualClusterName, sessionId, route, targetNodeId)
-                    .setCause(LOGGER.isDebugEnabled() ? e : null)
-                    .addKeyValue("error", e.getMessage())
-                    .log(LOGGER.isDebugEnabled()
-                            ? "Failed to forward request to node"
-                            : "Failed to forward request to node, increase log level to DEBUG for stacktrace");
-            return CompletableFuture.failedFuture(e);
-        }
+        fireChannelRead(frame);
 
         withSendContext(LOGGER.atTrace(), virtualClusterName, sessionId, route, clientCorrelationId)
                 .addKeyValue("targetNodeId", targetNodeId)

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -122,6 +122,11 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
         this.ctx = ctx;
     }
 
+    /**
+     * Completes all pending router response futures exceptionally before closing the
+     * router. This handles any case where the connection closes with outstanding
+     * requests (forwarding failure, backend crash, drain timeout, etc.).
+     */
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) {
         int abandoned = pendingResponses.size();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -124,13 +124,9 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) {
-        router.close();
-    }
-
-    @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         int abandoned = pendingResponses.size();
         if (abandoned > 0) {
+            var cause = new IllegalStateException("Connection closed with " + abandoned + " pending router response(s)");
             for (var entry : pendingResponses.values()) {
                 entry.future().completeExceptionally(cause);
             }
@@ -139,13 +135,9 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                     .addKeyValue("virtualCluster", virtualClusterName)
                     .addKeyValue("sessionId", ccsm.sessionId())
                     .addKeyValue("abandonedResponses", abandoned)
-                    .addKeyValue("error", cause.getMessage())
-                    .setCause(LOGGER.isDebugEnabled() ? cause : null)
-                    .log(LOGGER.isDebugEnabled()
-                            ? "Pipeline exception, abandoned pending router responses"
-                            : "Pipeline exception, abandoned pending router responses, increase log level to DEBUG for stacktrace");
+                    .log("Connection closed with pending router responses");
         }
-        ctx.fireExceptionCaught(cause);
+        router.close();
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -27,10 +27,10 @@ import org.slf4j.spi.LoggingEventBuilder;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.concurrent.EventExecutor;
 
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.Frame;
 import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
 import io.kroxylicious.proxy.internal.CorrelationIdAllocator;
@@ -94,7 +94,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
     private ResponseSequencer responseSequencer;
 
     @Nullable
-    private EventExecutor eventExecutor;
+    private ChannelHandlerContext ctx;
 
     @Nullable
     private final Integer nodeId;
@@ -119,7 +119,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) {
-        this.eventExecutor = ctx.executor();
+        this.ctx = ctx;
     }
 
     @Override
@@ -144,7 +144,8 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                 if (NODE_ID_TRANSLATION_APIS.contains(apiKey)) {
                     pendingRoutes.put(frame.correlationId(), staticRoute);
                 }
-                ccsm.forwardToRoute(staticRoute, msg);
+                ((Frame) msg).setRouteName(staticRoute);
+                ctx.fireChannelRead(msg);
                 LOGGER.atTrace()
                         .addKeyValue("virtualCluster", virtualClusterName)
                         .addKeyValue("sessionId", ccsm.sessionId())
@@ -162,11 +163,15 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
                     .addKeyValue("virtualCluster", virtualClusterName)
                     .addKeyValue("sessionId", ccsm.sessionId())
                     .addKeyValue("apiKey", apiKey)
-                    .log("Dynamically-routed API key arrived as opaque frame, forwarding to CCSM");
-            ccsm.onClientFilterChainComplete(msg);
+                    .log("Dynamically-routed API key arrived as opaque frame, forwarding via pipeline");
+            ctx.fireChannelRead(msg);
             return;
         }
-        ccsm.onClientFilterChainComplete(msg);
+        ctx.fireChannelRead(msg);
+    }
+
+    private void fireChannelRead(Object msg) {
+        Objects.requireNonNull(ctx, "fireChannelRead called before handlerAdded").fireChannelRead(msg);
     }
 
     private void dispatchDynamically(ChannelHandlerContext ctx, DecodedRequestFrame<?> frame) {
@@ -305,7 +310,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
     }
 
     private <T> CompletionStage<T> executeOnEventLoop(Supplier<CompletableFuture<T>> work) {
-        var executor = Objects.requireNonNull(eventExecutor, "sendRequest called before handlerAdded");
+        var executor = Objects.requireNonNull(ctx, "sendRequest called before handlerAdded").executor();
         if (executor.inEventLoop()) {
             return work.get();
         }
@@ -340,8 +345,10 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
         int routingCorrelationId = correlationIdAllocator.allocateId();
         var frame = new DecodedRequestFrame<>(requestApiVersion, routingCorrelationId, true, header, request);
 
+        frame.setRouteName(route);
+
         if (!frame.hasResponse()) {
-            ccsm.forwardToRoute(route, frame);
+            fireChannelRead(frame);
             withSendContext(LOGGER.atTrace(), virtualClusterName, sessionId, route, clientCorrelationId)
                     .addKeyValue("routingCorrelationId", routingCorrelationId)
                     .log("Fire-and-forget request sent to route (no response expected)");
@@ -352,7 +359,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
         pendingResponses.put(routingCorrelationId, new PendingResponse(future, route));
 
         try {
-            ccsm.forwardToRoute(route, frame);
+            fireChannelRead(frame);
         }
         catch (Exception e) {
             pendingResponses.remove(routingCorrelationId);
@@ -398,9 +405,11 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
         short requestApiVersion = header.requestApiVersion();
         int routingCorrelationId = correlationIdAllocator.allocateId();
         var frame = new DecodedRequestFrame<>(requestApiVersion, routingCorrelationId, true, header, request);
+        frame.setRouteName(route);
+        frame.setTargetVirtualNodeId(targetNodeId);
 
         if (!frame.hasResponse()) {
-            ccsm.forwardToNode(targetNodeId, route, frame);
+            fireChannelRead(frame);
             withSendContext(LOGGER.atTrace(), virtualClusterName, sessionId, route, clientCorrelationId)
                     .addKeyValue("targetNodeId", targetNodeId)
                     .addKeyValue("routingCorrelationId", routingCorrelationId)
@@ -412,7 +421,7 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
         pendingResponses.put(routingCorrelationId, new PendingResponse(future, route));
 
         try {
-            ccsm.forwardToNode(targetNodeId, route, frame);
+            fireChannelRead(frame);
         }
         catch (Exception e) {
             pendingResponses.remove(routingCorrelationId);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandler.java
@@ -129,10 +129,22 @@ public class RouterDispatchHandler extends ChannelDuplexHandler {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        for (var entry : pendingResponses.values()) {
-            entry.future().completeExceptionally(cause);
+        int abandoned = pendingResponses.size();
+        if (abandoned > 0) {
+            for (var entry : pendingResponses.values()) {
+                entry.future().completeExceptionally(cause);
+            }
+            pendingResponses.clear();
+            LOGGER.atWarn()
+                    .addKeyValue("virtualCluster", virtualClusterName)
+                    .addKeyValue("sessionId", ccsm.sessionId())
+                    .addKeyValue("abandonedResponses", abandoned)
+                    .addKeyValue("error", cause.getMessage())
+                    .setCause(LOGGER.isDebugEnabled() ? cause : null)
+                    .log(LOGGER.isDebugEnabled()
+                            ? "Pipeline exception, abandoned pending router responses"
+                            : "Pipeline exception, abandoned pending router responses, increase log level to DEBUG for stacktrace");
         }
-        pendingResponses.clear();
         ctx.fireExceptionCaught(cause);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
@@ -19,6 +19,7 @@ import io.kroxylicious.proxy.frame.DecodedFrame;
 import io.kroxylicious.proxy.frame.Frame;
 import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
+import io.kroxylicious.proxy.internal.CorrelationIdSpace;
 
 import static java.util.Objects.requireNonNull;
 
@@ -56,7 +57,8 @@ public class RoutingTerminalHandler extends ChannelDuplexHandler {
                 return;
             }
             boolean hasResponse = !(msg instanceof RequestFrame rf) || rf.hasResponse();
-            if (hasResponse) {
+            boolean isRouterInternal = CorrelationIdSpace.isRoutingCorrelationId(frame.correlationId());
+            if (hasResponse && !isRouterInternal) {
                 correlationIdToRoute.put(frame.correlationId(), routeName);
             }
             int targetNodeId = (frame instanceof DecodedFrame<?, ?> df) ? df.targetVirtualNodeId() : Frame.NO_TARGET_VIRTUAL_NODE_ID;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
@@ -62,20 +62,25 @@ public class RoutingTerminalHandler extends ChannelDuplexHandler {
                 correlationIdToRoute.put(frame.correlationId(), routeName);
             }
             int targetNodeId = (frame instanceof DecodedFrame<?, ?> df) ? df.targetVirtualNodeId() : Frame.NO_TARGET_VIRTUAL_NODE_ID;
-            if (targetNodeId >= 0) {
-                ccsm.forwardToNode(targetNodeId, routeName, msg);
-                LOGGER.atTrace()
-                        .addKeyValue("sessionId", ccsm.sessionId())
-                        .addKeyValue("route", routeName)
-                        .addKeyValue("virtualNodeId", targetNodeId)
-                        .log("Terminal forwarded to target node");
+            try {
+                if (targetNodeId >= 0) {
+                    ccsm.forwardToNode(targetNodeId, routeName, msg);
+                    LOGGER.atTrace()
+                            .addKeyValue("sessionId", ccsm.sessionId())
+                            .addKeyValue("route", routeName)
+                            .addKeyValue("virtualNodeId", targetNodeId)
+                            .log("Terminal forwarded to target node");
+                }
+                else {
+                    ccsm.forwardToRoute(routeName, msg);
+                    LOGGER.atTrace()
+                            .addKeyValue("sessionId", ccsm.sessionId())
+                            .addKeyValue("route", routeName)
+                            .log("Terminal forwarded to route bootstrap");
+                }
             }
-            else {
-                ccsm.forwardToRoute(routeName, msg);
-                LOGGER.atTrace()
-                        .addKeyValue("sessionId", ccsm.sessionId())
-                        .addKeyValue("route", routeName)
-                        .log("Terminal forwarded to route bootstrap");
+            catch (Exception e) {
+                ctx.channel().pipeline().fireExceptionCaught(e);
             }
         }
         else {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+import io.kroxylicious.proxy.frame.DecodedFrame;
+import io.kroxylicious.proxy.frame.Frame;
+import io.kroxylicious.proxy.frame.RequestFrame;
+import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Sits at the end of the routing section of the pipeline.
+ * <p>
+ * On the inbound (request) path it reads the frame's route name
+ * and forwards to the {@link ClientConnectionStateMachine} via the
+ * appropriate method, recording the correlation ID → route mapping for
+ * requests that expect a response.
+ * <p>
+ * On the outbound (response) path, backend responses arrive via the normal
+ * {@code channel.write()} path. This handler tags each response with the
+ * route name looked up from the correlation ID map, so that upstream route
+ * filter handlers and the dispatch handler can identify which route the
+ * response belongs to.
+ */
+public class RoutingTerminalHandler extends ChannelDuplexHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoutingTerminalHandler.class);
+
+    private final ClientConnectionStateMachine ccsm;
+    private final Map<Integer, String> correlationIdToRoute = new HashMap<>();
+
+    public RoutingTerminalHandler(ClientConnectionStateMachine ccsm) {
+        this.ccsm = requireNonNull(ccsm);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (msg instanceof Frame frame) {
+            String routeName = frame.routeName();
+            if (routeName == null) {
+                ccsm.onClientFilterChainComplete(msg);
+                return;
+            }
+            boolean hasResponse = !(msg instanceof RequestFrame rf) || rf.hasResponse();
+            if (hasResponse) {
+                correlationIdToRoute.put(frame.correlationId(), routeName);
+            }
+            int targetNodeId = (frame instanceof DecodedFrame<?, ?> df) ? df.targetVirtualNodeId() : Frame.NO_TARGET_VIRTUAL_NODE_ID;
+            if (targetNodeId >= 0) {
+                ccsm.forwardToNode(targetNodeId, routeName, msg);
+                LOGGER.atTrace()
+                        .addKeyValue("sessionId", ccsm.sessionId())
+                        .addKeyValue("route", routeName)
+                        .addKeyValue("virtualNodeId", targetNodeId)
+                        .log("Terminal forwarded to target node");
+            }
+            else {
+                ccsm.forwardToRoute(routeName, msg);
+                LOGGER.atTrace()
+                        .addKeyValue("sessionId", ccsm.sessionId())
+                        .addKeyValue("route", routeName)
+                        .log("Terminal forwarded to route bootstrap");
+            }
+        }
+        else {
+            ccsm.onClientFilterChainComplete(msg);
+        }
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof Frame frame) {
+            String route = correlationIdToRoute.remove(frame.correlationId());
+            if (route != null) {
+                frame.setRouteName(route);
+            }
+        }
+        ctx.write(msg, promise);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandler.java
@@ -62,25 +62,20 @@ public class RoutingTerminalHandler extends ChannelDuplexHandler {
                 correlationIdToRoute.put(frame.correlationId(), routeName);
             }
             int targetNodeId = (frame instanceof DecodedFrame<?, ?> df) ? df.targetVirtualNodeId() : Frame.NO_TARGET_VIRTUAL_NODE_ID;
-            try {
-                if (targetNodeId >= 0) {
-                    ccsm.forwardToNode(targetNodeId, routeName, msg);
-                    LOGGER.atTrace()
-                            .addKeyValue("sessionId", ccsm.sessionId())
-                            .addKeyValue("route", routeName)
-                            .addKeyValue("virtualNodeId", targetNodeId)
-                            .log("Terminal forwarded to target node");
-                }
-                else {
-                    ccsm.forwardToRoute(routeName, msg);
-                    LOGGER.atTrace()
-                            .addKeyValue("sessionId", ccsm.sessionId())
-                            .addKeyValue("route", routeName)
-                            .log("Terminal forwarded to route bootstrap");
-                }
+            if (targetNodeId >= 0) {
+                ccsm.forwardToNode(targetNodeId, routeName, msg);
+                LOGGER.atTrace()
+                        .addKeyValue("sessionId", ccsm.sessionId())
+                        .addKeyValue("route", routeName)
+                        .addKeyValue("virtualNodeId", targetNodeId)
+                        .log("Terminal forwarded to target node");
             }
-            catch (Exception e) {
-                ctx.channel().pipeline().fireExceptionCaught(e);
+            else {
+                ccsm.forwardToRoute(routeName, msg);
+                LOGGER.atTrace()
+                        .addKeyValue("sessionId", ccsm.sessionId())
+                        .addKeyValue("route", routeName)
+                        .log("Terminal forwarded to route bootstrap");
             }
         }
         else {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -174,7 +174,7 @@ public class VirtualClusterModel implements AutoCloseable {
         Map<String, FilterChainFactory> result = new HashMap<>();
         for (var entry : dr.routeDescriptors().entrySet()) {
             List<NamedFilterDefinition> routeFilters = entry.getValue().filters();
-            if (routeFilters != null && !routeFilters.isEmpty()) {
+            if (!routeFilters.isEmpty()) {
                 result.put(entry.getKey(), new FilterChainFactory(pfr, routeFilters));
             }
         }
@@ -318,6 +318,16 @@ public class VirtualClusterModel implements AutoCloseable {
         catch (RuntimeException e) {
             firstFailure = e;
         }
+        firstFailure = handleException(filterChainFactory, firstFailure);
+        for (var fcf : routeFilterChainFactories.values()) {
+            firstFailure = handleException(fcf, firstFailure);
+        }
+        if (firstFailure != null) {
+            throw firstFailure;
+        }
+    }
+
+    private RuntimeException handleException(FilterChainFactory filterChainFactory, RuntimeException firstFailure) {
         try {
             filterChainFactory.close();
         }
@@ -329,22 +339,7 @@ public class VirtualClusterModel implements AutoCloseable {
                 firstFailure.addSuppressed(e);
             }
         }
-        for (var fcf : routeFilterChainFactories.values()) {
-            try {
-                fcf.close();
-            }
-            catch (RuntimeException e) {
-                if (firstFailure == null) {
-                    firstFailure = e;
-                }
-                else {
-                    firstFailure.addSuppressed(e);
-                }
-            }
-        }
-        if (firstFailure != null) {
-            throw firstFailure;
-        }
+        return firstFailure;
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -45,6 +45,8 @@ import io.kroxylicious.proxy.config.tls.PlatformTrustProvider;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.config.tls.TrustOptions;
 import io.kroxylicious.proxy.config.tls.TrustProvider;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.internal.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.internal.filter.impl.TopicNameCacheFilter;
 import io.kroxylicious.proxy.internal.net.AddressingSpec;
 import io.kroxylicious.proxy.internal.net.AdvertisingSpec;
@@ -123,6 +125,12 @@ public class VirtualClusterModel implements AutoCloseable {
      */
     private final FilterChainFactory filterChainFactory;
 
+    /**
+     * Per-route filter chain factories, keyed by route name. Only populated for
+     * routes that declare filters. Empty for non-routed VCs.
+     */
+    private final Map<String, FilterChainFactory> routeFilterChainFactories;
+
     @VisibleForTesting
     public VirtualClusterModel(String clusterName,
                                TargetCluster targetCluster,
@@ -154,6 +162,23 @@ public class VirtualClusterModel implements AutoCloseable {
         this.filterChainFactory = pluginFactoryRegistry != null
                 ? new FilterChainFactory(pluginFactoryRegistry, filters)
                 : FilterChainFactory.empty();
+        this.routeFilterChainFactories = pluginFactoryRegistry != null
+                ? initRouteFilterChainFactories(pluginFactoryRegistry)
+                : Map.of();
+    }
+
+    private Map<String, FilterChainFactory> initRouteFilterChainFactories(PluginFactoryRegistry pfr) {
+        if (!(routing instanceof DynamicRouting dr)) {
+            return Map.of();
+        }
+        Map<String, FilterChainFactory> result = new HashMap<>();
+        for (var entry : dr.routeDescriptors().entrySet()) {
+            List<NamedFilterDefinition> routeFilters = entry.getValue().filters();
+            if (routeFilters != null && !routeFilters.isEmpty()) {
+                result.put(entry.getKey(), new FilterChainFactory(pfr, routeFilters));
+            }
+        }
+        return result;
     }
 
     /**
@@ -164,6 +189,19 @@ public class VirtualClusterModel implements AutoCloseable {
      */
     public FilterChainFactory filterChainFactory() {
         return filterChainFactory;
+    }
+
+    /**
+     * Creates per-connection filter instances for the given route. Returns an empty
+     * list if the route has no filter definitions.
+     */
+    public List<FilterAndInvoker> createRouteFilters(String routeName,
+                                                     FilterFactoryContext context) {
+        var fcf = routeFilterChainFactories.get(routeName);
+        if (fcf == null) {
+            return List.of();
+        }
+        return fcf.createFilters(context);
     }
 
     public Router createRouter() {
@@ -289,6 +327,19 @@ public class VirtualClusterModel implements AutoCloseable {
             }
             else {
                 firstFailure.addSuppressed(e);
+            }
+        }
+        for (var fcf : routeFilterChainFactories.values()) {
+            try {
+                fcf.close();
+            }
+            catch (RuntimeException e) {
+                if (firstFailure == null) {
+                    firstFailure = e;
+                }
+                else {
+                    firstFailure.addSuppressed(e);
+                }
             }
         }
         if (firstFailure != null) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -327,7 +327,8 @@ public class VirtualClusterModel implements AutoCloseable {
         }
     }
 
-    private RuntimeException handleException(FilterChainFactory filterChainFactory, RuntimeException firstFailure) {
+    private @Nullable RuntimeException handleException(FilterChainFactory filterChainFactory,
+                                                       @Nullable RuntimeException firstFailure) {
         try {
             filterChainFactory.close();
         }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigurationValidationTest.java
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.internal.routing.DirectRouting;
 import io.kroxylicious.proxy.internal.routing.DynamicRouting;
 import io.kroxylicious.proxy.internal.routing.RouteDescriptor;
@@ -50,6 +53,35 @@ class ConfigurationValidationTest {
         return new PluginFactoryRegistry() {
             @Override
             public <P> PluginFactory<P> pluginFactory(Class<P> pluginClass) {
+                if (pluginClass == FilterFactory.class) {
+                    return (PluginFactory<P>) new PluginFactory<FilterFactory<?, ?>>() {
+                        @Override
+                        public FilterFactory<?, ?> pluginInstance(String instanceName) {
+                            return new io.kroxylicious.proxy.filter.FilterFactory<>() {
+                                @Override
+                                public Object initialize(FilterFactoryContext context, Object config) {
+                                    return null;
+                                }
+
+                                @Override
+                                public Filter createFilter(FilterFactoryContext context, Object init) {
+                                    return new Filter() {
+                                    };
+                                }
+                            };
+                        }
+
+                        @Override
+                        public Class<?> configType(String instanceName) {
+                            return Void.class;
+                        }
+
+                        @Override
+                        public Set<String> registeredInstanceNames() {
+                            return Set.of();
+                        }
+                    };
+                }
                 return (PluginFactory<P>) new PluginFactory<RouterFactory<?, ?>>() {
                     @Override
                     public RouterFactory<?, ?> pluginInstance(String instanceName) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/RouteFilterHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/RouteFilterHandlerTest.java
@@ -159,6 +159,26 @@ class RouteFilterHandlerTest {
     }
 
     @Test
+    void onInternalRequestSetsRouteNameOnFrame() {
+        // Given
+        ApiVersionsRequestFilter filter = (apiVersion, header, request, context) -> {
+            context.sendRequest(header, request);
+            return context.forwardRequest(header, request);
+        };
+        buildChannel(filter, ROUTE_A);
+        var frame = decodedRequest(new ApiVersionsRequestData());
+        frame.setRouteName(ROUTE_A);
+
+        // When
+        channel.writeInbound(frame);
+
+        // Then
+        InternalRequestFrame<?> internalFrame = channel.readInbound();
+        assertThat(internalFrame).isNotNull();
+        assertThat(internalFrame.routeName()).isEqualTo(ROUTE_A);
+    }
+
+    @Test
     void internalResponseFrameAlwaysDelegatedRegardlessOfRoute() {
         // Given
         ApiVersionsResponseFilter filter = (apiVersion, header, response, context) -> context.forwardResponse(header, response);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/RouteFilterHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/RouteFilterHandlerTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import io.kroxylicious.proxy.config.CacheConfiguration;
+import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
+import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
+import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
+import io.kroxylicious.proxy.internal.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.internal.net.EndpointBinding;
+import io.kroxylicious.proxy.internal.net.EndpointGateway;
+import io.kroxylicious.proxy.internal.routing.DirectRouting;
+import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
+import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.proxy.service.NodeIdentificationStrategy;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RouteFilterHandlerTest {
+
+    private static final String ROUTE_A = "route-a";
+    private static final String ROUTE_B = "route-b";
+
+    private EmbeddedChannel channel;
+
+    @AfterEach
+    void tearDown() {
+        if (channel != null) {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void matchingRouteDecodedRequestIsFiltered() {
+        // Given
+        ApiVersionsRequestFilter filter = (apiVersion, header, request, context) -> context.forwardRequest(header, request);
+        buildChannel(filter, ROUTE_A);
+        var frame = decodedRequest(new ApiVersionsRequestData());
+        frame.setRouteName(ROUTE_A);
+
+        // When
+        channel.writeInbound(frame);
+
+        // Then
+        assertThat((Object) channel.readInbound()).isSameAs(frame);
+    }
+
+    @Test
+    void nonMatchingRouteDecodedRequestPassesThrough() {
+        // Given
+        ApiVersionsRequestFilter filter = (apiVersion, header, request, context) -> {
+            throw new AssertionError("Filter should not be invoked for non-matching route");
+        };
+        buildChannel(filter, ROUTE_A);
+        var frame = decodedRequest(new ApiVersionsRequestData());
+        frame.setRouteName(ROUTE_B);
+
+        // When
+        channel.writeInbound(frame);
+
+        // Then
+        assertThat((Object) channel.readInbound()).isSameAs(frame);
+    }
+
+    @Test
+    void noRouteNameDecodedRequestPassesThrough() {
+        // Given
+        ApiVersionsRequestFilter filter = (apiVersion, header, request, context) -> {
+            throw new AssertionError("Filter should not be invoked when no routing context");
+        };
+        buildChannel(filter, ROUTE_A);
+        var frame = decodedRequest(new ApiVersionsRequestData());
+
+        // When
+        channel.writeInbound(frame);
+
+        // Then
+        assertThat((Object) channel.readInbound()).isSameAs(frame);
+    }
+
+    @Test
+    void matchingRouteDecodedResponseIsFiltered() {
+        // Given
+        ApiVersionsResponseFilter filter = (apiVersion, header, response, context) -> context.forwardResponse(header, response);
+        buildChannel(filter, ROUTE_A);
+        var frame = decodedResponse(new ApiVersionsResponseData());
+        frame.setRouteName(ROUTE_A);
+
+        // When
+        channel.writeOutbound(frame);
+
+        // Then
+        assertThat((Object) channel.readOutbound()).isSameAs(frame);
+    }
+
+    @Test
+    void nonMatchingRouteDecodedResponsePassesThrough() {
+        // Given
+        ApiVersionsResponseFilter filter = (apiVersion, header, response, context) -> {
+            throw new AssertionError("Filter should not be invoked for non-matching route");
+        };
+        buildChannel(filter, ROUTE_A);
+        var frame = decodedResponse(new ApiVersionsResponseData());
+        frame.setRouteName(ROUTE_B);
+
+        // When
+        channel.writeOutbound(frame);
+
+        // Then
+        assertThat((Object) channel.readOutbound()).isSameAs(frame);
+    }
+
+    @Test
+    void internalRequestFrameAlwaysDelegatedRegardlessOfRoute() {
+        // Given
+        ApiVersionsRequestFilter filter = (apiVersion, header, request, context) -> context.forwardRequest(header, request);
+        buildChannel(filter, ROUTE_A);
+        var header = requestHeader(new ApiVersionsRequestData());
+        var internalFrame = new InternalRequestFrame<>(
+                header.requestApiVersion(), header.correlationId(), false,
+                filter, new CompletableFuture<>(), header, new ApiVersionsRequestData());
+
+        // When
+        channel.writeInbound(internalFrame);
+
+        // Then
+        assertThat((Object) channel.readInbound()).isSameAs(internalFrame);
+    }
+
+    @Test
+    void internalResponseFrameAlwaysDelegatedRegardlessOfRoute() {
+        // Given
+        ApiVersionsResponseFilter filter = (apiVersion, header, response, context) -> context.forwardResponse(header, response);
+        buildChannel(filter, ROUTE_A);
+        var header = new ResponseHeaderData().setCorrelationId(42);
+        var future = new CompletableFuture<>();
+        var internalFrame = new InternalResponseFrame<>(
+                filter, ApiKeys.API_VERSIONS.latestVersion(), 42, header, new ApiVersionsResponseData(), future);
+
+        // When
+        channel.writeOutbound(internalFrame);
+
+        // Then
+        assertThat(future).isCompleted();
+    }
+
+    @Test
+    void opaqueRequestWithMatchingRoutePassesThrough() {
+        // Given
+        ApiVersionsRequestFilter filter = (apiVersion, header, request, context) -> {
+            throw new AssertionError("Filter should not be invoked for opaque frames");
+        };
+        buildChannel(filter, ROUTE_A);
+        ByteBuf buffer = Unpooled.buffer();
+        var opaqueFrame = new OpaqueRequestFrame(buffer, ApiKeys.PRODUCE.id, ApiKeys.PRODUCE.latestVersion(), 55, false, buffer.readableBytes(), false);
+        opaqueFrame.setRouteName(ROUTE_A);
+
+        // When
+        channel.writeOneInbound(opaqueFrame);
+
+        // Then
+        assertThat((Object) channel.readInbound()).isSameAs(opaqueFrame);
+    }
+
+    @Test
+    void opaqueResponseWithNonMatchingRoutePassesThrough() {
+        // Given
+        buildChannel((ApiVersionsResponseFilter) (apiVersion, header, response, context) -> {
+            throw new AssertionError("Filter should not be invoked for opaque frames");
+        }, ROUTE_A);
+        ByteBuf buffer = Unpooled.buffer(4);
+        buffer.writeInt(55);
+        var opaqueFrame = new OpaqueResponseFrame(ApiKeys.PRODUCE.id, ApiKeys.PRODUCE.latestVersion(), buffer, 55, buffer.readableBytes());
+        opaqueFrame.setRouteName(ROUTE_B);
+
+        // When
+        channel.writeOutbound(opaqueFrame);
+
+        // Then
+        assertThat((Object) channel.readOutbound()).isSameAs(opaqueFrame);
+    }
+
+    @Test
+    void filterDescriptorIncludesRouteName() {
+        // Given
+        ApiVersionsRequestFilter filter = (apiVersion, header, request, context) -> context.forwardRequest(header, request);
+        buildChannel(filter, ROUTE_A);
+
+        // When
+        RouteFilterHandler handler = (RouteFilterHandler) channel.pipeline().get("routeFilter");
+
+        // Then
+        assertThat(handler.filterDescriptor()).contains("[route=" + ROUTE_A + "]");
+    }
+
+    private void buildChannel(Filter filter, String routeName) {
+        final TargetCluster targetCluster = mock(TargetCluster.class);
+        when(targetCluster.bootstrapServersList()).thenReturn(List.of(HostPort.parse("targetCluster:9091")));
+        var testVirtualCluster = new VirtualClusterModel("TestVirtualCluster", new DirectRouting("upstream", targetCluster), false,
+                false, List.of(), CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), null);
+        testVirtualCluster.addGateway("default", mock(NodeIdentificationStrategy.class), Optional.empty());
+        var inboundChannel = new EmbeddedChannel();
+
+        var endpointBinding = mock(EndpointBinding.class);
+        when(endpointBinding.nodeId()).thenReturn(0);
+        var gw = mock(EndpointGateway.class);
+        when(gw.virtualCluster()).thenReturn(testVirtualCluster);
+        when(endpointBinding.endpointGateway()).thenReturn(gw);
+
+        var kafkaSession = new KafkaSession(KafkaSessionState.ESTABLISHING);
+        var ccsm = new ClientConnectionStateMachine(endpointBinding, new DefaultSubjectBuilder(List.of()), kafkaSession);
+        var forwarding = new ClientConnectionState.Forwarding();
+        var mockScsm = mock(ServerConnectionStateMachine.class);
+        ccsm.forceState(
+                forwarding,
+                mock(KafkaProxyFrontendHandler.class),
+                java.util.Map.of(new HostPort("broker", 9092), mockScsm),
+                kafkaSession,
+                true);
+
+        FilterAndInvoker filterAndInvoker = getOnlyElement(FilterAndInvoker.build(filter.getClass().getSimpleName(), filter));
+        ChannelHandler routeFilterHandler = new RouteFilterHandler(filterAndInvoker, 1000L, null, inboundChannel, ccsm, routeName);
+
+        channel = new EmbeddedChannel();
+        channel.pipeline().addLast("routeFilter", routeFilterHandler);
+    }
+
+    private <B extends ApiMessage> DecodedRequestFrame<B> decodedRequest(B data) {
+        var header = requestHeader(data);
+        return new DecodedRequestFrame<>(header.requestApiVersion(), header.correlationId(), false, header, data);
+    }
+
+    private <B extends ApiMessage> RequestHeaderData requestHeader(B data) {
+        var apiKey = ApiKeys.forId(data.apiKey());
+        var header = new RequestHeaderData();
+        header.setCorrelationId(42);
+        header.setRequestApiKey(apiKey.id);
+        header.setRequestApiVersion(apiKey.latestVersion());
+        header.setClientId("test-client");
+        return header;
+    }
+
+    private <B extends ApiMessage> DecodedResponseFrame<B> decodedResponse(B data) {
+        var apiKey = ApiKeys.forId(data.apiKey());
+        var header = new ResponseHeaderData();
+        header.setCorrelationId(42);
+        return new DecodedResponseFrame<>(apiKey.latestVersion(), 42, header, data);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/FilterChangeDetectorTest.java
@@ -12,9 +12,13 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
+import io.kroxylicious.proxy.config.RouteDefinition;
+import io.kroxylicious.proxy.config.RouteTarget;
+import io.kroxylicious.proxy.config.RouterDefinition;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.VirtualClusterGateway;
@@ -173,7 +177,15 @@ class FilterChangeDetectorTest {
     private static Configuration configWith(@Nullable List<NamedFilterDefinition> filterDefs,
                                             @Nullable List<String> defaultFilters,
                                             VirtualCluster... clusters) {
-        return new Configuration(null, null, filterDefs, defaultFilters, null, List.of(clusters), null, false,
+        return configWith(filterDefs, defaultFilters, null, null, clusters);
+    }
+
+    private static Configuration configWith(@Nullable List<NamedFilterDefinition> filterDefs,
+                                            @Nullable List<String> defaultFilters,
+                                            @Nullable List<ClusterDefinition> clusterDefs,
+                                            @Nullable List<RouterDefinition> routerDefs,
+                                            VirtualCluster... clusters) {
+        return new Configuration(null, clusterDefs, filterDefs, defaultFilters, routerDefs, List.of(clusters), null, false,
                 Optional.empty(), null, null);
     }
 
@@ -206,6 +218,23 @@ class FilterChangeDetectorTest {
                 false,
                 false,
                 filters);
+    }
+
+    private static VirtualCluster routedVc(String name, String routerName) {
+        var gateway = new VirtualClusterGateway("default",
+                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9192), null, null, null),
+                null,
+                Optional.empty());
+        return new VirtualCluster(name,
+                null,
+                new RouteTarget(null, routerName),
+                List.of(gateway),
+                false,
+                false,
+                List.of(),
+                null,
+                null,
+                null);
     }
 
     @Test
@@ -268,6 +297,45 @@ class FilterChangeDetectorTest {
         // "uses-a" is flagged because filter-a's content changed; "isolated" is not — it
         // has no filter chain so a filter-definition change can't affect it.
         assertThat(result.clustersToModify()).containsExactly("uses-a");
+    }
+
+    @Test
+    void detectsRouteFilterDefinitionChange() {
+        // Given
+        var oldFilter = filterDef("route-filter", "config-v1");
+        var newFilter = filterDef("route-filter", "config-v2");
+        var clusterDef = new ClusterDefinition("c1", "broker:9092", null);
+        var route = new RouteDefinition("r1", 0, List.of("route-filter"), new RouteTarget("c1", null));
+        var routerDef = new RouterDefinition("myrouter", "FakeRouter", null, List.of(route));
+        var routedVc = routedVc("routed-vc", "myrouter");
+
+        var oldConfig = configWith(List.of(oldFilter), null, List.of(clusterDef), List.of(routerDef), routedVc);
+        var newConfig = configWith(List.of(newFilter), null, List.of(clusterDef), List.of(routerDef), routedVc);
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then
+        assertThat(result.clustersToModify()).containsExactly("routed-vc");
+    }
+
+    @Test
+    void doesNotFlagRoutedVcWhenRouteFilterDefinitionUnchanged() {
+        // Given
+        var filter = filterDef("route-filter", "same-config");
+        var clusterDef = new ClusterDefinition("c1", "broker:9092", null);
+        var route = new RouteDefinition("r1", 0, List.of("route-filter"), new RouteTarget("c1", null));
+        var routerDef = new RouterDefinition("myrouter", "FakeRouter", null, List.of(route));
+        var routedVc = routedVc("routed-vc", "myrouter");
+
+        var oldConfig = configWith(List.of(filter), null, List.of(clusterDef), List.of(routerDef), routedVc);
+        var newConfig = configWith(List.of(filter), null, List.of(clusterDef), List.of(routerDef), routedVc);
+
+        // When
+        var result = detector.detect(new ConfigurationChangeContext(oldConfig, newConfig));
+
+        // Then
+        assertThat(result.isEmpty()).isTrue();
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/RoutingGraphChangeDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/reload/RoutingGraphChangeDetectorTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.config.RouteDefinition;
 import io.kroxylicious.proxy.config.RouteTarget;
@@ -489,6 +490,42 @@ class RoutingGraphChangeDetectorTest {
         return new ConfigurationChangeContext(oldConfig, newConfig);
     }
 
+    @Test
+    void detectsFilterAddedToRoute() {
+        // Given
+        var filterDef = new NamedFilterDefinition("my-filter", "FakeFilter", "cfg");
+        var routeWithoutFilter = new RouteDefinition("route", 0, List.of(), new RouteTarget("upstream", null));
+        var routeWithFilter = new RouteDefinition("route", 0, List.of("my-filter"), new RouteTarget("upstream", null));
+        var oldRouter = new RouterDefinition("r1", "SomeRouterType", "cfg", List.of(routeWithoutFilter));
+        var newRouter = new RouterDefinition("r1", "SomeRouterType", "cfg", List.of(routeWithFilter));
+        var oldConfig = configWithFilters(List.of(UPSTREAM), List.of(oldRouter), null, vcWithRouter("cluster-a", "r1"));
+        var newConfig = configWithFilters(List.of(UPSTREAM), List.of(newRouter), List.of(filterDef), vcWithRouter("cluster-a", "r1"));
+
+        // When
+        var result = detector.detect(ctx(oldConfig, newConfig));
+
+        // Then
+        assertThat(result.clustersToModify()).containsExactly("cluster-a");
+    }
+
+    @Test
+    void detectsFilterRemovedFromRoute() {
+        // Given
+        var filterDef = new NamedFilterDefinition("my-filter", "FakeFilter", "cfg");
+        var routeWithFilter = new RouteDefinition("route", 0, List.of("my-filter"), new RouteTarget("upstream", null));
+        var routeWithoutFilter = new RouteDefinition("route", 0, List.of(), new RouteTarget("upstream", null));
+        var oldRouter = new RouterDefinition("r1", "SomeRouterType", "cfg", List.of(routeWithFilter));
+        var newRouter = new RouterDefinition("r1", "SomeRouterType", "cfg", List.of(routeWithoutFilter));
+        var oldConfig = configWithFilters(List.of(UPSTREAM), List.of(oldRouter), List.of(filterDef), vcWithRouter("cluster-a", "r1"));
+        var newConfig = configWithFilters(List.of(UPSTREAM), List.of(newRouter), null, vcWithRouter("cluster-a", "r1"));
+
+        // When
+        var result = detector.detect(ctx(oldConfig, newConfig));
+
+        // Then
+        assertThat(result.clustersToModify()).containsExactly("cluster-a");
+    }
+
     private static ClusterDefinition clusterDef(String name, String bootstrapServers) {
         return new ClusterDefinition(name, bootstrapServers, null);
     }
@@ -526,6 +563,14 @@ class RoutingGraphChangeDetectorTest {
                                         @Nullable List<RouterDefinition> routerDefs,
                                         VirtualCluster... clusters) {
         return new Configuration(null, clusterDefs, null, null, routerDefs, List.of(clusters), null, false,
+                Optional.empty(), null, null);
+    }
+
+    private static Configuration configWithFilters(@Nullable List<ClusterDefinition> clusterDefs,
+                                                   @Nullable List<RouterDefinition> routerDefs,
+                                                   @Nullable List<NamedFilterDefinition> filterDefs,
+                                                   VirtualCluster... clusters) {
+        return new Configuration(null, clusterDefs, filterDefs, null, routerDefs, List.of(clusters), null, false,
                 Optional.empty(), null, null);
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -37,11 +37,8 @@ import io.kroxylicious.proxy.router.Router;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyShort;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -618,35 +615,18 @@ class RouterDispatchHandlerTest {
     }
 
     @Test
-    void sendToAnyNodeShouldReturnFailedFutureWhenForwardThrows() {
+    void pendingFuturesCompletedExceptionallyWhenConnectionCloses() {
         // Given
-        doThrow(new RuntimeException("forward failed")).when(ccsm).forwardToRoute(anyString(), any());
         var handler = handlerWithRouteForSendTests(DEFAULT_ROUTE);
         channel = channelWithTerminal(handler);
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.FETCH.id)
                 .setRequestApiVersion((short) 12);
-
-        // When
         var future = handler.sendToAnyNode(DEFAULT_ROUTE, header, new FetchRequestData(), "test-session", 100);
-
-        // Then
-        assertThat(future.toCompletableFuture()).isCompletedExceptionally();
-        assertThat(handler.pendingResponses).isEmpty();
-    }
-
-    @Test
-    void sendToSpecificNodeShouldReturnFailedFutureWhenForwardThrows() {
-        // Given
-        doThrow(new RuntimeException("forward failed")).when(ccsm).forwardToNode(anyInt(), anyString(), any());
-        var handler = handlerWithRouteForSendTests(DEFAULT_ROUTE);
-        channel = channelWithTerminal(handler);
-        var header = new RequestHeaderData()
-                .setRequestApiKey(ApiKeys.FETCH.id)
-                .setRequestApiVersion((short) 12);
+        assertThat(future.toCompletableFuture()).isNotDone();
 
         // When
-        var future = handler.sendToSpecificNode(3, DEFAULT_ROUTE, header, new FetchRequestData(), "test-session", 100);
+        channel.close();
 
         // Then
         assertThat(future.toCompletableFuture()).isCompletedExceptionally();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -64,11 +64,15 @@ class RouterDispatchHandlerTest {
                 router, Map.of(), staticRoutes, ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
     }
 
+    private EmbeddedChannel channelWithTerminal(RouterDispatchHandler handler) {
+        return new EmbeddedChannel(handler, new RoutingTerminalHandler(ccsm));
+    }
+
     @Test
     void shouldForwardNonFrameMessageToCcsm() {
         // Given
         var handler = handlerWithIdentityMapping(Map.of());
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
 
         // When
         channel.writeInbound("not-a-frame");
@@ -103,7 +107,7 @@ class RouterDispatchHandlerTest {
         // Given
         var staticRoutes = Map.of(ApiKeys.PRODUCE, DEFAULT_ROUTE);
         var handler = handlerWithIdentityMapping(staticRoutes);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
 
         var buf = Unpooled.buffer();
         var opaqueFrame = new OpaqueRequestFrame(buf, ApiKeys.FETCH.id, (short) 12, CORRELATION_ID, false, 0, true);
@@ -121,7 +125,7 @@ class RouterDispatchHandlerTest {
         // Given
         var staticRoutes = Map.of(ApiKeys.FETCH, DEFAULT_ROUTE);
         var handler = handlerWithIdentityMapping(staticRoutes);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
 
         var frame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true,
                 new RequestHeaderData(), new FetchRequestData());
@@ -131,6 +135,7 @@ class RouterDispatchHandlerTest {
 
         // Then
         verify(ccsm).forwardToRoute(DEFAULT_ROUTE, frame);
+        assertThat(frame.routeName()).isEqualTo(DEFAULT_ROUTE);
     }
 
     @Test
@@ -138,7 +143,7 @@ class RouterDispatchHandlerTest {
         // Given
         var staticRoutes = Map.of(ApiKeys.FETCH, DEFAULT_ROUTE);
         var handler = handlerWithIdentityMapping(staticRoutes);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
 
         var buf = Unpooled.buffer();
         var opaqueFrame = new OpaqueRequestFrame(buf, ApiKeys.FETCH.id, (short) 12, CORRELATION_ID, false, 0, true);
@@ -148,6 +153,7 @@ class RouterDispatchHandlerTest {
 
         // Then
         verify(ccsm).forwardToRoute(DEFAULT_ROUTE, opaqueFrame);
+        assertThat(opaqueFrame.routeName()).isEqualTo(DEFAULT_ROUTE);
         buf.release();
     }
 
@@ -157,7 +163,7 @@ class RouterDispatchHandlerTest {
         var mapping = new BijectiveNodeIdMapping(Map.of("route-a", 0, "route-b", 1), 2);
         var handler = new RouterDispatchHandler(
                 router, Map.of(), Map.of(ApiKeys.METADATA, "route-a"), ccsm, "test-cluster", mapping, null);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
 
         // Record the pending METADATA request
         var requestFrame = new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true,
@@ -441,7 +447,7 @@ class RouterDispatchHandlerTest {
         var handler = new RouterDispatchHandler(
                 router, Map.of(DEFAULT_ROUTE, new RouteDescriptor(DEFAULT_ROUTE, 0, new TargetCluster("localhost:9092", null), null, List.of())),
                 Map.of(), ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
 
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.PRODUCE.id)
@@ -468,7 +474,7 @@ class RouterDispatchHandlerTest {
         var handler = new RouterDispatchHandler(
                 router, Map.of(DEFAULT_ROUTE, new RouteDescriptor(DEFAULT_ROUTE, 0, new TargetCluster("localhost:9092", null), null, List.of())),
                 Map.of(), ccsm, "test-cluster", new IdentityNodeIdMapping(DEFAULT_ROUTE), null);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
 
         int routingCorrelationId = Integer.MIN_VALUE / 2;
         var frame = new DecodedResponseFrame<>((short) 9, routingCorrelationId,
@@ -486,7 +492,7 @@ class RouterDispatchHandlerTest {
     void sendToAnyNodeShouldForwardToRouteForKnownRoute() {
         // Given
         var handler = handlerWithRouteForSendTests(DEFAULT_ROUTE);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.FETCH.id)
                 .setRequestApiVersion((short) 12);
@@ -544,7 +550,7 @@ class RouterDispatchHandlerTest {
     void sendToAnyNodeShouldReturnCompletedNullFutureForFireAndForget() {
         // Given: PRODUCE with acks=0 has hasResponse()=false, so no response is expected
         var handler = handlerWithRouteForSendTests(DEFAULT_ROUTE);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.PRODUCE.id)
                 .setRequestApiVersion((short) 9);
@@ -561,7 +567,7 @@ class RouterDispatchHandlerTest {
     void sendToSpecificNodeShouldForwardToNode() {
         // Given
         var handler = handlerWithRouteForSendTests(DEFAULT_ROUTE);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.FETCH.id)
                 .setRequestApiVersion((short) 12);
@@ -597,7 +603,7 @@ class RouterDispatchHandlerTest {
     void sendToSpecificNodeShouldNotRegisterPendingResponseForFireAndForgetRequest() {
         // Given: PRODUCE with acks=0 has hasResponse()=false, so no response is expected
         var handler = handlerWithRouteForSendTests(DEFAULT_ROUTE);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.PRODUCE.id)
                 .setRequestApiVersion((short) 9);
@@ -616,7 +622,7 @@ class RouterDispatchHandlerTest {
         // Given
         doThrow(new RuntimeException("forward failed")).when(ccsm).forwardToRoute(anyString(), any());
         var handler = handlerWithRouteForSendTests(DEFAULT_ROUTE);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.FETCH.id)
                 .setRequestApiVersion((short) 12);
@@ -625,10 +631,8 @@ class RouterDispatchHandlerTest {
         var future = handler.sendToAnyNode(DEFAULT_ROUTE, header, new FetchRequestData(), "test-session", 100);
 
         // Then
-        assertThat(future.toCompletableFuture()).isCompletedExceptionally();
-        assertThatThrownBy(() -> future.toCompletableFuture().get())
-                .hasCauseInstanceOf(RuntimeException.class)
-                .cause().hasMessage("forward failed");
+        assertThat(future.toCompletableFuture()).isNotDone();
+        assertThat(handler.pendingResponses).hasSize(1);
     }
 
     @Test
@@ -636,7 +640,7 @@ class RouterDispatchHandlerTest {
         // Given
         doThrow(new RuntimeException("forward failed")).when(ccsm).forwardToNode(anyInt(), anyString(), any());
         var handler = handlerWithRouteForSendTests(DEFAULT_ROUTE);
-        channel = new EmbeddedChannel(handler);
+        channel = channelWithTerminal(handler);
         var header = new RequestHeaderData()
                 .setRequestApiKey(ApiKeys.FETCH.id)
                 .setRequestApiVersion((short) 12);
@@ -645,9 +649,7 @@ class RouterDispatchHandlerTest {
         var future = handler.sendToSpecificNode(3, DEFAULT_ROUTE, header, new FetchRequestData(), "test-session", 100);
 
         // Then
-        assertThat(future.toCompletableFuture()).isCompletedExceptionally();
-        assertThatThrownBy(() -> future.toCompletableFuture().get())
-                .hasCauseInstanceOf(RuntimeException.class)
-                .cause().hasMessage("forward failed");
+        assertThat(future.toCompletableFuture()).isNotDone();
+        assertThat(handler.pendingResponses).hasSize(1);
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouterDispatchHandlerTest.java
@@ -631,8 +631,8 @@ class RouterDispatchHandlerTest {
         var future = handler.sendToAnyNode(DEFAULT_ROUTE, header, new FetchRequestData(), "test-session", 100);
 
         // Then
-        assertThat(future.toCompletableFuture()).isNotDone();
-        assertThat(handler.pendingResponses).hasSize(1);
+        assertThat(future.toCompletableFuture()).isCompletedExceptionally();
+        assertThat(handler.pendingResponses).isEmpty();
     }
 
     @Test
@@ -649,7 +649,7 @@ class RouterDispatchHandlerTest {
         var future = handler.sendToSpecificNode(3, DEFAULT_ROUTE, header, new FetchRequestData(), "test-session", 100);
 
         // Then
-        assertThat(future.toCompletableFuture()).isNotDone();
-        assertThat(handler.pendingResponses).hasSize(1);
+        assertThat(future.toCompletableFuture()).isCompletedExceptionally();
+        assertThat(handler.pendingResponses).isEmpty();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandlerTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
+import io.kroxylicious.proxy.internal.CorrelationIdSpace;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -169,6 +170,34 @@ class RoutingTerminalHandlerTest {
         DecodedResponseFrame<?> out = channel.readOutbound();
         assertThat(out).isNotNull();
         assertThat(out.routeName()).isNull();
+    }
+
+    @Test
+    void shouldNotRecordCorrelationIdForRouterInternalRequest() {
+        // Given
+        when(ccsm.sessionId()).thenReturn("test-session");
+        var handler = new RoutingTerminalHandler(ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        int routingCorrelationId = CorrelationIdSpace.RESERVED_ROUTING_ID_RANGE_START_INC;
+        var header = new RequestHeaderData()
+                .setRequestApiKey(ApiKeys.FETCH.id)
+                .setRequestApiVersion((short) 12)
+                .setCorrelationId(routingCorrelationId);
+        var frame = new DecodedRequestFrame<>((short) 12, routingCorrelationId, true, header, new FetchRequestData());
+        frame.setRouteName(ROUTE_A);
+        channel.writeInbound(frame);
+
+        var response = new DecodedResponseFrame<>((short) 12, routingCorrelationId,
+                new ResponseHeaderData(), new FetchResponseData());
+
+        // When
+        channel.writeOutbound(response);
+
+        // Then
+        DecodedResponseFrame<?> out = channel.readOutbound();
+        assertThat(out).isNotNull();
+        assertThat(out.routeName()).as("router-internal correlation IDs must not be recorded, so no route name is set on the response").isNull();
     }
 
     private DecodedRequestFrame<FetchRequestData> fetchRequest() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RoutingTerminalHandlerTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.routing;
+
+import org.apache.kafka.common.message.FetchRequestData;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.internal.ClientConnectionStateMachine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RoutingTerminalHandlerTest {
+
+    private static final int CORRELATION_ID = 42;
+    private static final String ROUTE_A = "route-a";
+
+    @Mock
+    private ClientConnectionStateMachine ccsm;
+
+    private EmbeddedChannel channel;
+
+    @AfterEach
+    void tearDown() {
+        if (channel != null) {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    void shouldForwardToRouteForRouteDefaultNode() {
+        // Given
+        var handler = new RoutingTerminalHandler(ccsm);
+        channel = new EmbeddedChannel(handler);
+        var frame = fetchRequest();
+        frame.setRouteName(ROUTE_A);
+
+        // When
+        channel.writeInbound(frame);
+
+        // Then
+        verify(ccsm).forwardToRoute(ROUTE_A, frame);
+    }
+
+    @Test
+    void shouldForwardToNodeForRouteTargetNode() {
+        // Given
+        var handler = new RoutingTerminalHandler(ccsm);
+        channel = new EmbeddedChannel(handler);
+        var frame = fetchRequest();
+        frame.setRouteName(ROUTE_A);
+        frame.setTargetVirtualNodeId(7);
+
+        // When
+        channel.writeInbound(frame);
+
+        // Then
+        verify(ccsm).forwardToNode(7, ROUTE_A, frame);
+    }
+
+    @Test
+    void shouldFallBackToFilterChainCompleteWhenNoRouteName() {
+        // Given
+        var handler = new RoutingTerminalHandler(ccsm);
+        channel = new EmbeddedChannel(handler);
+        var frame = fetchRequest();
+
+        // When
+        channel.writeInbound(frame);
+
+        // Then
+        verify(ccsm).onClientFilterChainComplete(frame);
+    }
+
+    @Test
+    void shouldFallBackToFilterChainCompleteForNonFrameMessage() {
+        // Given
+        var handler = new RoutingTerminalHandler(ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        // When
+        channel.writeInbound("not-a-frame");
+
+        // Then
+        verify(ccsm).onClientFilterChainComplete("not-a-frame");
+    }
+
+    @Test
+    void writeShouldSetRouteNameForKnownCorrelationId() {
+        // Given
+        when(ccsm.sessionId()).thenReturn("test-session");
+        var handler = new RoutingTerminalHandler(ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        var request = fetchRequest();
+        request.setRouteName(ROUTE_A);
+        channel.writeInbound(request);
+
+        var response = new DecodedResponseFrame<>((short) 12, CORRELATION_ID,
+                new ResponseHeaderData(), new FetchResponseData());
+
+        // When
+        channel.writeOutbound(response);
+
+        // Then
+        DecodedResponseFrame<?> out = channel.readOutbound();
+        assertThat(out).isNotNull();
+        assertThat(out.routeName()).isEqualTo(ROUTE_A);
+    }
+
+    @Test
+    void writeShouldNotSetRouteNameForUnknownCorrelationId() {
+        // Given
+        var handler = new RoutingTerminalHandler(ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        var response = new DecodedResponseFrame<>((short) 12, 9999,
+                new ResponseHeaderData(), new FetchResponseData());
+
+        // When
+        channel.writeOutbound(response);
+
+        // Then
+        DecodedResponseFrame<?> out = channel.readOutbound();
+        assertThat(out).isNotNull();
+        assertThat(out.routeName()).isNull();
+    }
+
+    @Test
+    void writeShouldNotSetRouteNameForFireAndForgetRequest() {
+        // Given
+        when(ccsm.sessionId()).thenReturn("test-session");
+        var handler = new RoutingTerminalHandler(ccsm);
+        channel = new EmbeddedChannel(handler);
+
+        var header = new RequestHeaderData()
+                .setRequestApiKey(ApiKeys.PRODUCE.id)
+                .setRequestApiVersion((short) 9)
+                .setCorrelationId(CORRELATION_ID);
+        var frame = new DecodedRequestFrame<>((short) 9, CORRELATION_ID, false, header, new ProduceRequestData().setAcks((short) 0));
+        frame.setRouteName(ROUTE_A);
+        channel.writeInbound(frame);
+
+        var response = new DecodedResponseFrame<>((short) 9, CORRELATION_ID,
+                new ResponseHeaderData(), new FetchResponseData());
+
+        // When
+        channel.writeOutbound(response);
+
+        // Then
+        DecodedResponseFrame<?> out = channel.readOutbound();
+        assertThat(out).isNotNull();
+        assertThat(out.routeName()).isNull();
+    }
+
+    private DecodedRequestFrame<FetchRequestData> fetchRequest() {
+        var header = new RequestHeaderData()
+                .setRequestApiKey(ApiKeys.FETCH.id)
+                .setRequestApiVersion((short) 12)
+                .setCorrelationId(CORRELATION_ID);
+        return new DecodedRequestFrame<>((short) 12, CORRELATION_ID, true, header, new FetchRequestData());
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -229,6 +229,49 @@ class VirtualClusterModelTest {
     }
 
     @Test
+    void createRouteFiltersShouldReturnDistinctInstancesWhenTwoRoutesShareSameFilterName() {
+        // Given
+        var sharedFilterName = "flaky";
+        var flakyConfig = new FlakyConfig(null, null, null, c -> {
+        }, c -> {
+        });
+        var filterDef = new NamedFilterDefinition(sharedFilterName, FlakyFactory.class.getName(), flakyConfig);
+        var routeA = new RouteDescriptor("route-a", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of(filterDef));
+        var routeB = new RouteDescriptor("route-b", 1, new TargetCluster("broker:9093", Optional.empty()), null, List.of(filterDef));
+        var model = new VirtualClusterModel("vc",
+                new DynamicRouting("myrouter", Map.of("route-a", routeA, "route-b", routeB), mock(RouterChainFactory.class)),
+                false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), combinedPluginFactoryRegistry());
+        var filterContext = mock(io.kroxylicious.proxy.filter.FilterFactoryContext.class);
+
+        // When
+        var filtersA = model.createRouteFilters("route-a", filterContext);
+        var filtersB = model.createRouteFilters("route-b", filterContext);
+
+        // Then
+        assertThat(filtersA).hasSize(1);
+        assertThat(filtersB).hasSize(1);
+        assertThat(filtersA.get(0).filter()).isNotSameAs(filtersB.get(0).filter());
+    }
+
+    @Test
+    void createRouteFiltersShouldReturnEmptyListForRouteWithNoFilters() {
+        // Given
+        var route = new RouteDescriptor("route-a", 0, new TargetCluster("broker:9092", Optional.empty()), null, List.of());
+        var model = new VirtualClusterModel("vc",
+                new DynamicRouting("myrouter", Map.of("route-a", route), mock(RouterChainFactory.class)),
+                false, false, EMPTY_FILTERS,
+                CacheConfiguration.DEFAULT, null, Duration.ofSeconds(10), combinedPluginFactoryRegistry());
+        var filterContext = mock(io.kroxylicious.proxy.filter.FilterFactoryContext.class);
+
+        // When
+        var filters = model.createRouteFilters("route-a", filterContext);
+
+        // Then
+        assertThat(filters).isEmpty();
+    }
+
+    @Test
     void closeStillClosesFilterChainFactoryWhenRouterChainFactoryCloseThrows() {
         // Given: a RouterChainFactory that throws on close
         var rcf = mock(RouterChainFactory.class);


### PR DESCRIPTION
RouteFilterHandler.channelRead passes every InternalRequestFrame to super.channelRead() without checking route ownership, so a filter on route-b processes internal requests originated by a filter on route-a.

The new C5 test in RouteFilterCorrectnessIT places a RequestCountingFilter on route-b and a RequestResponseMarkingFilter (ASYNCHRONOUS_REQUEST_TO_BROKER) on route-a. The marking filter fires an InternalRequestFrame carrying ListGroupsRequestData when it sees PRODUCE. Route-b receives no client traffic, so its LIST_GROUPS count must stay zero. With the bug the count is non-zero because the InternalRequestFrame crosses the route boundary.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>