### PR TITLE
Do not set fsGroup on openshift

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentDependentResource.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentDependentResource.java
@@ -29,6 +29,7 @@ import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteIngress;
 import io.fabric8.openshift.api.model.RouteStatus;
+import io.fabric8.openshift.api.model.SecurityContextConstraints;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.BooleanWithUndefined;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
@@ -114,7 +115,7 @@ public class ProxyDeploymentDependentResource
                     .editOrNewSelector()
                     .withMatchLabels(deploymentSelector(primary))
                     .endSelector()
-                    .withTemplate(podTemplate(primary, kafkaProxyContext, model.networkingModel(), model.clustersWithValidNetworking(), checksum))
+                    .withTemplate(podTemplate(primary, kafkaProxyContext, model.networkingModel(), model.clustersWithValidNetworking(), checksum, context))
                 .endSpec()
                 .build();
         // @formatter:on
@@ -184,7 +185,8 @@ public class ProxyDeploymentDependentResource
                                         KafkaProxyContext kafkaProxyContext,
                                         ProxyNetworkingModel ingressModel,
                                         List<ClusterResolutionResult> clusterResolutionResults,
-                                        String checksum) {
+                                        String checksum,
+                                        Context<KafkaProxy> context) {
         PodTemplateSpecFluent<PodTemplateSpecBuilder>.MetadataNested<PodTemplateSpecBuilder> metadataBuilder = new PodTemplateSpecBuilder()
                 .editOrNewMetadata()
                 .addToLabels(podLabels(primary));
@@ -192,17 +194,24 @@ public class ProxyDeploymentDependentResource
             Annotations.annotateWithReferentChecksum(metadataBuilder, checksum);
         }
 
+        // fsGroup forces a volume ownership change to the given GID on mount, which OpenShift's
+        // restricted SCC forbids (it assigns fsGroup from a per-namespace range instead).
+        boolean isOpenShift = context.getClient().supports(SecurityContextConstraints.class);
+
         // @formatter:off
-        return metadataBuilder
+        var specBuilder = metadataBuilder
                 .endMetadata()
                 .editOrNewSpec()
                     .withNewSecurityContext()
                         .withRunAsNonRoot(true)
-                        .withFsGroup(185L)
                         .withNewSeccompProfile()
                             .withType("RuntimeDefault")
                         .endSeccompProfile()
-                    .endSecurityContext()
+                    .endSecurityContext();
+        if (!isOpenShift) {
+            specBuilder = specBuilder.editSecurityContext().withFsGroup(185L).endSecurityContext();
+        }
+        return specBuilder
                     .withContainers(proxyContainer(primary, kafkaProxyContext, ingressModel, clusterResolutionResults))
                     .addNewVolume()
                         .withName(CONFIG_VOLUME)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.Route;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.DefaultManagedWorkflowAndDependentResourceContext;
@@ -319,6 +320,7 @@ class DerivedResourcesTest {
                                                     List<Route> routes)
             throws IOException {
         Context<KafkaProxy> context = mock(Context.class);
+        doReturn(mock(KubernetesClient.class)).when(context).getClient();
 
         var resourceContext = new DefaultManagedWorkflowAndDependentResourceContext(null, null, context);
         resourceContext.put(Crc32ChecksumGenerator.CHECKSUM_CONTEXT_KEY, new FixedChecksumGenerator(123654L));

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentTest.java
@@ -23,6 +23,8 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.SecurityContextConstraints;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.DefaultManagedWorkflowAndDependentResourceContext;
 
@@ -106,6 +108,31 @@ class ProxyDeploymentTest {
     }
 
     @Test
+    void shouldSetFsGroupOnVanillaKubernetes() {
+        // Given
+        ProxyDeploymentDependentResource proxyDeploymentDependentResource = new ProxyDeploymentDependentResource();
+
+        // When
+        Deployment actual = proxyDeploymentDependentResource.desired(kafkaProxy, kubernetesContext);
+
+        // Then
+        assertThat(actual.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup()).isEqualTo(185L);
+    }
+
+    @Test
+    void shouldNotSetFsGroupOnOpenShift() {
+        // Given
+        when(kubernetesContext.getClient().supports(SecurityContextConstraints.class)).thenReturn(true);
+        ProxyDeploymentDependentResource proxyDeploymentDependentResource = new ProxyDeploymentDependentResource();
+
+        // When
+        Deployment actual = proxyDeploymentDependentResource.desired(kafkaProxy, kubernetesContext);
+
+        // Then
+        assertThat(actual.getSpec().getTemplate().getSpec().getSecurityContext().getFsGroup()).isNull();
+    }
+
+    @Test
     void shouldSpecifySecCompProfile() {
         // Given
         ProxyDeploymentDependentResource proxyDeploymentDependentResource = new ProxyDeploymentDependentResource();
@@ -159,6 +186,8 @@ class ProxyDeploymentTest {
         var proxyModel = new ProxyModel(EMPTY_RESOLUTION_RESULT, new ProxyNetworkingModel(List.of()), List.of(clusterResolutionResultFor(virtualKafkaCluster)));
 
         Context<KafkaProxy> context = mock(Context.class);
+        KubernetesClient client = mock(KubernetesClient.class);
+        when(context.getClient()).thenReturn(client);
         resourceContext = new DefaultManagedWorkflowAndDependentResourceContext<>(null, kafkaProxy, context);
         configureProxyModel(proxyModel);
         when(context.managedWorkflowAndDependentResourceContext()).thenReturn(resourceContext);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Omit `fsGroup` on openshift

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist. 
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, add a [logchange](https://logchange.dev/tools/logchange/usage/#basic-structure) entry YAML file to `changelog/unreleased/` (remember to include changes affecting the API of the test artefacts too). See [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#changelog-entries) for the entry format.
