### PR TITLE
test(it): add reproducer ITs for OOB node-ID double-translation via nested router

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/NestedRouterOobIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/NestedRouterOobIT.java
@@ -9,9 +9,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.DescribeClusterRequestData;
 import org.apache.kafka.common.message.DescribeClusterResponseData;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +23,9 @@ import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 import io.kroxylicious.it.testplugins.OutOfBandSendFilterFactory;
 import io.kroxylicious.it.testplugins.RequestResponseMarkingFilter;
 import io.kroxylicious.it.testplugins.RequestResponseMarkingFilterFactory;
+import io.kroxylicious.it.testplugins.router.ClientIdRouterFactory;
 import io.kroxylicious.it.testplugins.router.DynamicProduceRouterFactory;
+import io.kroxylicious.it.testplugins.router.OobMetadataCaptureRouterFactory;
 import io.kroxylicious.it.testplugins.router.PassThroughRouterFactory;
 import io.kroxylicious.proxy.config.ClusterDefinition;
 import io.kroxylicious.proxy.config.RouteDefinition;
@@ -41,6 +45,7 @@ import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils
 import static io.kroxylicious.testing.integration.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
 import static org.apache.kafka.common.protocol.ApiKeys.CREATE_TOPICS;
 import static org.apache.kafka.common.protocol.ApiKeys.DESCRIBE_CLUSTER;
+import static org.apache.kafka.common.protocol.ApiKeys.METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -118,6 +123,137 @@ class NestedRouterOobIT {
                     "filterNameTaggedFieldsFromOutOfBandResponse: "
                             + RequestResponseMarkingFilter.class.getSimpleName() + "-inner-marker-response");
         }
+    }
+
+    /**
+     * Verifies that the broker node IDs received by an outer router from an OOB METADATA
+     * request through a nested router reflect only the nested level's virtual node ID
+     * translation — not a second translation applied at the outer level.
+     *
+     * <p>Topology: outer router (2 routes → BijectiveMapping at outer level) sends OOB
+     * METADATA to a nested router (2 routes → BijectiveMapping at inner level) where
+     * METADATA is statically routed to "backend-a". The mock cluster returns broker
+     * nodeId=1; the inner BijectiveMapping translates that to nested-virtual 2 (routeId=0,
+     * S=2: 0 + 2×1 = 2). The outer router should receive nodeId=2.
+     */
+    @Test
+    void outerRouterShouldReceiveCorrectNodeIdsFromOobViaNestedStaticRoute() {
+        // Given
+        OobMetadataCaptureRouterFactory.reset();
+
+        // Inner router: statically routes everything to "backend-a"; 2 routes force BijectiveMapping
+        var innerRouteA = new RouteDefinition("backend-a", 0, List.of(), new RouteTarget("mock-cluster", null));
+        var innerRouteB = new RouteDefinition("backend-b", 1, List.of(), new RouteTarget("mock-cluster", null));
+        var innerRouter = new RouterDefinition("inner",
+                PassThroughRouterFactory.class.getName(),
+                new PassThroughRouterFactory.Config("backend-a"),
+                List.of(innerRouteA, innerRouteB));
+
+        // Outer router: 2 routes force BijectiveMapping; "to-unused" is never exercised
+        var outerRoute = new RouteDefinition("to-nested", 0, List.of(), new RouteTarget(null, "inner"));
+        var unusedRoute = new RouteDefinition("to-unused", 1, List.of(), new RouteTarget("mock-cluster", null));
+        var outerRouter = new RouterDefinition("outer",
+                OobMetadataCaptureRouterFactory.class.getName(),
+                new OobMetadataCaptureRouterFactory.Config("to-nested"),
+                List.of(outerRoute, unusedRoute));
+
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, "outer"))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(OS_ASSIGNED_BOOTSTRAP).build())
+                .build();
+
+        try (var tester = KroxyliciousTesters.mockKafkaKroxyliciousTester(s -> {
+            var clusterDef = new ClusterDefinition("mock-cluster", s, null);
+            return baseConfigurationBuilder()
+                    .addToClusterDefinitions(clusterDef)
+                    .addToRouterDefinitions(outerRouter, innerRouter)
+                    .addToVirtualClusters(vc);
+        }, ROUTING_ENABLED);
+                var client = tester.simpleTestClient()) {
+
+            tester.addMockResponseForApiKey(new ResponsePayload(METADATA, METADATA.latestVersion(), metadataResponseWithNodeId(1)));
+            tester.addMockResponseForApiKey(new ResponsePayload(CREATE_TOPICS, CREATE_TOPICS.latestVersion(), arbitraryCreateTopicsResponse()));
+
+            // When
+            client.getSync(new Request(CREATE_TOPICS, CREATE_TOPICS.latestVersion(), "client", new CreateTopicsRequestData()));
+
+            // Then: inner BijectiveMapping(S=2, "backend-a"→id=0): toVirtual("backend-a", 1) = 0 + 2×1 = 2
+            assertThat(OobMetadataCaptureRouterFactory.capturedBrokerIds())
+                    .as("OOB METADATA broker nodeId should be translated by the inner level only")
+                    .containsExactly(2);
+        }
+    }
+
+    /**
+     * Verifies that the broker node IDs received by an outer router from an OOB METADATA
+     * request through a nested router reflect only the nested level's virtual node ID
+     * translation — not a second translation applied at the outer level.
+     *
+     * <p>This variant uses a nested router that routes METADATA dynamically (via
+     * {@code onRequest}) rather than via a static route, exercising the path where the
+     * outer router's OOB frame is dispatched to the nested router's {@code onRequest},
+     * which issues its own OOB to the cluster.
+     */
+    @Test
+    void outerRouterShouldReceiveCorrectNodeIdsFromOobViaNestedDynamicRoute() {
+        // Given
+        OobMetadataCaptureRouterFactory.reset();
+
+        // Inner router: all requests dynamic (ClientIdRouterFactory has no staticRoutes());
+        // 2 routes force BijectiveMapping; default route ensures OOB header always resolves to "backend-a"
+        var innerRouteA = new RouteDefinition("backend-a", 0, List.of(), new RouteTarget("mock-cluster", null));
+        var innerRouteB = new RouteDefinition("backend-b", 1, List.of(), new RouteTarget("mock-cluster", null));
+        var innerConfig = new ClientIdRouterFactory.Config(Map.of(), "backend-a");
+        var innerRouter = new RouterDefinition("inner",
+                ClientIdRouterFactory.class.getName(),
+                innerConfig,
+                List.of(innerRouteA, innerRouteB));
+
+        // Outer router: 2 routes force BijectiveMapping; "to-unused" is never exercised
+        var outerRoute = new RouteDefinition("to-nested", 0, List.of(), new RouteTarget(null, "inner"));
+        var unusedRoute = new RouteDefinition("to-unused", 1, List.of(), new RouteTarget("mock-cluster", null));
+        var outerRouter = new RouterDefinition("outer",
+                OobMetadataCaptureRouterFactory.class.getName(),
+                new OobMetadataCaptureRouterFactory.Config("to-nested"),
+                List.of(outerRoute, unusedRoute));
+
+        var vc = new VirtualClusterBuilder()
+                .withName("demo")
+                .withTarget(new RouteTarget(null, "outer"))
+                .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(OS_ASSIGNED_BOOTSTRAP).build())
+                .build();
+
+        try (var tester = KroxyliciousTesters.mockKafkaKroxyliciousTester(s -> {
+            var clusterDef = new ClusterDefinition("mock-cluster", s, null);
+            return baseConfigurationBuilder()
+                    .addToClusterDefinitions(clusterDef)
+                    .addToRouterDefinitions(outerRouter, innerRouter)
+                    .addToVirtualClusters(vc);
+        }, ROUTING_ENABLED);
+                var client = tester.simpleTestClient()) {
+
+            tester.addMockResponseForApiKey(new ResponsePayload(METADATA, METADATA.latestVersion(), metadataResponseWithNodeId(1)));
+            tester.addMockResponseForApiKey(new ResponsePayload(CREATE_TOPICS, CREATE_TOPICS.latestVersion(), arbitraryCreateTopicsResponse()));
+
+            // When
+            client.getSync(new Request(CREATE_TOPICS, CREATE_TOPICS.latestVersion(), "client", new CreateTopicsRequestData()));
+
+            // Then: inner BijectiveMapping(S=2, "backend-a"→id=0): toVirtual("backend-a", 1) = 0 + 2×1 = 2
+            assertThat(OobMetadataCaptureRouterFactory.capturedBrokerIds())
+                    .as("OOB METADATA broker nodeId should be translated by the inner level only")
+                    .containsExactly(2);
+        }
+    }
+
+    private static MetadataResponseData metadataResponseWithNodeId(int nodeId) {
+        var broker = new MetadataResponseData.MetadataResponseBroker();
+        broker.setNodeId(nodeId);
+        broker.setHost("mock-host");
+        broker.setPort(9092);
+        var response = new MetadataResponseData();
+        response.brokers().add(broker);
+        return response;
     }
 
     private static CreateTopicsResponseData arbitraryCreateTopicsResponse() {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/OobMetadataCaptureRouterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/router/OobMetadataCaptureRouterFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it.testplugins.router;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.router.Router;
+import io.kroxylicious.proxy.router.RouterFactory;
+import io.kroxylicious.proxy.router.RouterFactoryContext;
+
+/**
+ * A test router that, for each inbound request, first sends an out-of-band METADATA
+ * request to {@link Config#route()}, captures the broker node IDs from the response,
+ * then forwards the original request to the same route. Used in tests to verify that
+ * node-ID translation is applied exactly once when an outer router dispatches OOB
+ * requests through a nested router.
+ */
+@Plugin(configType = OobMetadataCaptureRouterFactory.Config.class)
+public class OobMetadataCaptureRouterFactory
+        implements RouterFactory<OobMetadataCaptureRouterFactory.Config, OobMetadataCaptureRouterFactory.Config> {
+
+    public record Config(String route) {}
+
+    private static final AtomicReference<List<Integer>> capturedBrokerIds = new AtomicReference<>();
+
+    public static void reset() {
+        capturedBrokerIds.set(null);
+    }
+
+    public static List<Integer> capturedBrokerIds() {
+        return capturedBrokerIds.get();
+    }
+
+    @Override
+    public Config initialize(RouterFactoryContext context, Config config) {
+        return config;
+    }
+
+    @Override
+    public Router createRouter(RouterFactoryContext context, Config config) {
+        return (apiKey, apiVersion, header, request, ctx) -> {
+            var metadataRequest = new MetadataRequestData();
+            var metadataHeader = new RequestHeaderData()
+                    .setRequestApiKey(ApiKeys.METADATA.id)
+                    .setRequestApiVersion(metadataRequest.highestSupportedVersion())
+                    .setClientId(header.clientId());
+            return ctx.sendRequest(ctx.anyNode(config.route()), metadataHeader, metadataRequest)
+                    .thenCompose(metadataBody -> {
+                        var md = (MetadataResponseData) metadataBody;
+                        capturedBrokerIds.set(md.brokers().stream()
+                                .map(MetadataResponseData.MetadataResponseBroker::nodeId)
+                                .collect(Collectors.toList()));
+                        return ctx.sendRequest(ctx.anyNode(config.route()), header, request);
+                    })
+                    .thenCompose(body -> ctx.respondWith(body).completed());
+        };
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.router.RouterFactory
@@ -9,6 +9,7 @@ io.kroxylicious.it.testplugins.router.ContextCapturingRouterFactory
 io.kroxylicious.it.testplugins.router.DynamicProduceRouterFactory
 io.kroxylicious.it.testplugins.router.InvocationCountingRouterFactory
 io.kroxylicious.it.testplugins.router.NodeTargetingProduceRouterFactory
+io.kroxylicious.it.testplugins.router.OobMetadataCaptureRouterFactory
 io.kroxylicious.it.testplugins.router.PassThroughRouterFactory
 io.kroxylicious.it.testplugins.router.RouterContractCapturingFactory
 io.kroxylicious.it.testplugins.router.SplitStaticRouterFactory


### PR DESCRIPTION
### Problem

When an outer router sends an OOB request through a route that targets a nested router, and the outer router has `BijectiveNodeIdMapping` (which kicks in when it has 2+ routes), node IDs in the response get
  translated twice: once correctly by the inner dispatcher, once incorrectly by the outer dispatcher.

### Topology

```
  Client
    └─ outer router (2 routes → BijectiveMapping, S=2)
         ├─ "to-nested" (routeId=0) → inner router
         │    ├─ "backend-a" (routeId=0) → Cluster A (1 broker, nodeId=1)
         │    └─ "backend-b" (routeId=1) → Cluster B (not exercised)
         └─ "to-cluster" (routeId=1) → Cluster C (not exercised)
```

Inner router also has 2 routes → BijectiveMapping(S=2).

### Flow

Outer router sends OOB METADATA via `ctx.sendRequest(ctx.anyNode("to-nested"), ...)`.

1. Outer RouteDispatcher records a PendingResponse for this OOB, keyed to the outer BijectiveMapping(S=2).
2. Request reaches inner RoutingHandler. Inner router routes to "backend-a" → Cluster A.
3. Cluster A returns METADATA: nodeId=1.
4. Inner RouteDispatcher translates for "backend-a": `toVirtual("backend-a", 1) = 0 + 2×1 = 2`. Inner OOB future resolves with nodeId=2.
5. Inner router calls ctx.respondWith(nodeId=2). Response frame (nodeId=2) travels back up to outer RouteDispatcher.handleResponse.
6. Outer RouteDispatcher finds the PendingResponse with outer BijectiveMapping(S=2). Translates nodeId=2 in the MetadataResponseData body: `toVirtual("to-nested", 2) = 0 + 2×2 = 4`. Completes the OOB future with
   the mutated ApiMessage.

The outer router's sendRequest future resolves with a `MetadataResponseData` whose single broker entry has nodeId=4. The router lambda sees `((MetadataResponseData) metadataBody).brokers().get(0).nodeId() == 4`.
Correct value is 2.

### Consequence

If the outer router subsequently calls `ctx.specificNode("to-nested", 4)`, the frame propagates to the inner RoutingHandler with targetVirtualNodeId=4. Inner BijectiveMapping resolves: `routeId = 4 % 2 = 0
  ("backend-a"), realNodeId = (4 - 0) / 2 = 2`. Cluster A has no node with ID 2 — the intended broker was 1. Request goes to the wrong broker.

### Conditions

  - Only manifests when the outer router has 2+ routes (1 route → IdentityMapping, translation is a no-op).
  - Only affects API responses that carry node IDs: METADATA, FIND_COORDINATOR, DESCRIBE_CLUSTER, PRODUCE, FETCH, and variants.
  - Same double-translation applies on the static route path: when a client request is statically routed through a router-targeting route, the outer dispatcher translates node IDs in the response that the inner
    has already translated.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>