### PR TITLE
fix(runtime): consume router OOB response at the level that issued it

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/PathElement.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/PathElement.java
@@ -257,19 +257,44 @@ public sealed interface PathElement permits PathElement.RoutePosition, PathEleme
 
     /**
      * A router's own identity: an internally-issued request made by the router itself, awaiting
-     * {@code promise}. {@code position()} is always a concrete {@link Route} - routing an
-     * out-of-band request always targets a named route, never the bare client origin.
+     * {@code promise}. Both routes are always a concrete {@link Route} - routing an out-of-band
+     * request always targets a named route, never the bare client origin.
+     * <p>
+     * Unlike a {@link FilterOriginator}, a router-issued request carries no name/ordinal identity,
+     * so the {@code issuedAt} route is what identifies the dispatcher level that issued it: it is
+     * the route the request was originally issued to, and is <em>never</em> changed by
+     * {@link #graft}/{@link #reposition}. {@code RouteDispatcher} matches a returning response to
+     * its issuing level by comparing {@code issuedAt}'s parent against that level's own parent path,
+     * which is why grafting a deeper route beneath the originator (e.g. when {@code issuedAt} itself
+     * targets a nested router) must not disturb it - see {@code RouteDispatcher.handleResponse}.
      *
      * @param promise the promise to complete when the response arrives
-     * @param position the route level this router is installed at
+     * @param issuedAt the route this request was issued to - the stable identity of the issuing
+     *        dispatcher level, never deepened by {@link #reposition}
+     * @param position the current route position, which {@link #reposition} may deepen (e.g. when a
+     *        nested router resolves a further route beneath {@code issuedAt}) so that route-scoped
+     *        filters on the resolved route still recognise the frame as belonging to their route
      */
     record RouterOriginator(
                             CompletableFuture<?> promise,
+                            Route issuedAt,
                             Route position)
             implements Originator {
+
+        /**
+         * Creates an originator sitting exactly at the route it was issued to, before any
+         * {@link #reposition} has deepened its position.
+         *
+         * @param promise the promise to complete when the response arrives
+         * @param route the route this request was issued to
+         */
+        public RouterOriginator(CompletableFuture<?> promise, Route route) {
+            this(promise, route, route);
+        }
+
         @Override
         public Originator reposition(Route newPosition) {
-            return new RouterOriginator(promise, newPosition);
+            return new RouterOriginator(promise, issuedAt, newPosition);
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouteDispatcher.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/routing/RouteDispatcher.java
@@ -280,14 +280,18 @@ public class RouteDispatcher implements RouterDispatch {
 
     ResponseOutcome handleResponse(DecodedResponseFrame<?> frame, String sessionId) {
         PathElement routing = frame.routing();
-        if (routing instanceof PathElement.RouterOriginator(CompletableFuture<?> promise, PathElement.Route routeSegment)
-                && Objects.equals(routeSegment.parent(), parentPath)) {
+        // Match on issuedAt (the route this OOB request was issued to), not the possibly-deeper
+        // position: a nested router may have grafted a further route beneath the originator, but the
+        // promise is still owned by - and must be translated by - the level that issued it. issuedAt
+        // is never deepened by grafting, so issuedAt.parent() uniquely identifies the issuing level.
+        if (routing instanceof PathElement.RouterOriginator(CompletableFuture<?> promise, PathElement.Route issuedAt, PathElement.Route ignored)
+                && Objects.equals(issuedAt.parent(), parentPath)) {
             @SuppressWarnings("unchecked")
             CompletableFuture<ApiMessage> future = (CompletableFuture<ApiMessage>) promise;
             pendingPromises.remove(future);
             ApiMessage body = frame.body();
             try {
-                NodeIdResponseTranslator.translate(body, frame.apiVersion(), nodeIdMapping, localRouteName(routeSegment));
+                NodeIdResponseTranslator.translate(body, frame.apiVersion(), nodeIdMapping, localRouteName(issuedAt));
                 cacheNodeAddressesIfMetadata(body, sessionId);
                 future.complete(body);
             }
@@ -304,7 +308,7 @@ public class RouteDispatcher implements RouterDispatch {
             LOGGER.atTrace()
                     .addKeyValue(LOG_KEY_VIRTUAL_CLUSTER, virtualClusterName)
                     .addKeyValue(LOG_KEY_SESSION_ID, sessionId)
-                    .addKeyValue(LOG_KEY_ROUTE, routeSegment.name())
+                    .addKeyValue(LOG_KEY_ROUTE, issuedAt.name())
                     .log("Routed response matched to pending request");
             return ResponseOutcome.CONSUMED;
         }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/frame/PathElementTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/frame/PathElementTest.java
@@ -150,7 +150,7 @@ class PathElementTest {
         var grafted = originator.graft(newPosition);
 
         // Then
-        assertThat(grafted).isEqualTo(new RouterOriginator(promise, newPosition));
+        assertThat(grafted).isEqualTo(new RouterOriginator(promise, OUTER_ROUTE, newPosition));
     }
 
     // --- Originator.reposition() ---
@@ -180,7 +180,7 @@ class PathElementTest {
         var repositioned = originator.reposition(newPosition);
 
         // Then
-        assertThat(repositioned).isEqualTo(new RouterOriginator(promise, newPosition));
+        assertThat(repositioned).isEqualTo(new RouterOriginator(promise, OUTER_ROUTE, newPosition));
     }
 
     // --- RoutePosition.parent() ---

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouteDispatcherTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/routing/RouteDispatcherTest.java
@@ -514,6 +514,51 @@ class RouteDispatcherTest {
         assertThat(responseFrame.refCnt()).isZero();
     }
 
+    /**
+     * A {@link PathElement.RouterOriginator} must be consumed only by the dispatcher level that
+     * issued it - the invariant asserted at {@code RoutingHandler.write} ("only ever consumed by
+     * the dispatcher level that issued it").
+     *
+     * <p>Reproduces the nested-routing case: a top-level router issues an out-of-band request to a
+     * route ({@code routeR}) that itself targets a nested router {@code N}. {@code N} intercepts the
+     * request and statically routes it onward to its own {@code innerRoute}, grafting its resolved
+     * route onto the carried originator exactly as {@code RoutingHandler.dispatchStaticRoute} does.
+     * When the response returns, the nested dispatcher must <em>not</em> claim it: the promise
+     * belongs to the outer router, which alone knows the correct {@link NodeIdMapping} and route
+     * name to translate the response with, and which alone is tracking the promise for
+     * connection-close cleanup.
+     */
+    @Test
+    void nestedDispatcherMustNotConsumeAnOuterRouterOriginator() {
+        // Given
+        when(correlationIdAllocator.allocateId()).thenReturn(ROUTING_CORRELATION_ID);
+        var outer = createDispatcher(Map.of("routeR", routerRoute("routeR", 0, "N")), "");
+        var outerFuture = outer.sendToAnyNode("routeR", fetchHeader(), new FetchRequestData(), SESSION_ID, CLIENT_CORRELATION_ID);
+        DecodedRequestFrame<?> fired = channel.readInbound();
+        PathElement issuedByOuter = fired.routing();
+
+        var nested = new RouteDispatcher(
+                Map.of("innerRoute", clusterRoute("innerRoute", 0)),
+                new IdentityNodeIdMapping("innerRoute"),
+                "N/",
+                issuedByOuter.routePosition(),
+                correlationIdAllocator, new HashMap<>(), "test-cluster");
+        PathElement grafted = issuedByOuter.graft(nested.routePathFor("innerRoute"));
+        var responseFrame = new DecodedResponseFrame<>((short) 12, ROUTING_CORRELATION_ID, new ResponseHeaderData(), new FetchResponseData());
+        responseFrame.setRouting(grafted);
+
+        // When
+        var outcome = nested.handleResponse(responseFrame, SESSION_ID);
+
+        // Then
+        assertThat(outcome)
+                .as("the nested level did not issue this out-of-band request, so it must not claim the response")
+                .isEqualTo(RouteDispatcher.ResponseOutcome.UNHANDLED);
+        assertThat(outerFuture.toCompletableFuture())
+                .as("the outer router's promise must be left for the level that issued it")
+                .isNotDone();
+    }
+
     // --- failAllPending ---
 
     @Test


### PR DESCRIPTION
## Purpose

Fixes a defect in PR #4824's routing rework (surfaced by review), where a router-issued out-of-band (OOB) request whose route targets a **nested router** has its response consumed at the wrong dispatcher level. Contains a failing-then-fixed regression test plus the fix.

## The defect

When a top-level router issues an OOB request to route `routeR`, and `routeR` targets nested router `N`:

1. The top-level dispatcher stamps `RouterOriginator(promise, Route("routeR", ClientOrigin))`.
2. `N` intercepts, statically routes onward to its own `innerRoute`, and `dispatchStaticRoute` → `graft` deepens the originator's position to `Route("N/innerRoute", Route("routeR", ClientOrigin))`.
3. On the response, `RouteDispatcher.handleResponse` matched purely on the (grafted) position: `routeSegment.parent() == parentPath`. That equality now holds at **N**, so N completes the **outer** router's promise — translating with N's `NodeIdMapping`/route instead of the issuer's — and the issuing dispatcher never removes the future from its own `pendingPromises` (it leaks until connection close).

This violated the invariant asserted in `RoutingHandler.write`: a `RouterOriginator` is *"only ever consumed by the dispatcher level that issued it"*.

## The fix

Mirror how `FilterOriginator` already survives grafting (its `name`+`ordinal` are preserved by `reposition`, and `FilterHandler.isRecipient` matches on that stable identity). `RouterOriginator` had no stable identity, so this adds one:

- `RouterOriginator` gains a stable **`issuedAt`** route — the route it was originally issued to — which `reposition`/`graft` never deepen. `position` continues to deepen so downstream route-scoped filters still intercept the frame.
- `RouteDispatcher.handleResponse` now matches and translates on `issuedAt`, so the response is consumed by the level that issued it regardless of any deeper graft.

Because `issuedAt` is never deepened, `issuedAt.parent() == parentPath` selects exactly one level — the issuer.

## Tests

- New `RouteDispatcherTest.nestedDispatcherMustNotConsumeAnOuterRouterOriginator` reproduces the scenario (applying the graft exactly as `RoutingHandler.dispatchStaticRoute` does) and asserts the nested level returns `UNHANDLED`, leaving the outer promise untouched. Red before the fix, green after.
- `PathElementTest` graft/reposition assertions updated to reflect that `issuedAt` is preserved and only `position` changes.

Full `PathElementTest`, `RouteDispatcherTest`, `RoutingHandlerTest`, `RoutingTerminalHandlerTest`, `ClientConnectionStateMachineTest` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)